### PR TITLE
Add removeWorker method on WorkerInfoDAO

### DIFF
--- a/src/main/java/net/greghaines/jesque/meta/dao/WorkerInfoDAO.java
+++ b/src/main/java/net/greghaines/jesque/meta/dao/WorkerInfoDAO.java
@@ -33,4 +33,6 @@ public interface WorkerInfoDAO
 	WorkerInfo getWorker(String workerName);
 	
 	Map<String,List<WorkerInfo>> getWorkerHostMap();
+
+	void removeWorker(String workerName);
 }

--- a/src/main/java/net/greghaines/jesque/meta/dao/impl/WorkerInfoDAORedisImpl.java
+++ b/src/main/java/net/greghaines/jesque/meta/dao/impl/WorkerInfoDAORedisImpl.java
@@ -235,4 +235,26 @@ public class WorkerInfoDAORedisImpl implements WorkerInfoDAO
 		}
 		return workerInfo;
 	}
+
+	/**
+	 * Remove the metadata about a worker
+	 *
+	 * @param workerName The worker name to remove
+	 */
+	public void removeWorker(final String workerName) {
+		PoolUtils.doWorkInPoolNicely(this.jedisPool, new PoolWork<Jedis,Void>()
+		{
+			public Void doWork(final Jedis jedis)
+			throws Exception
+			{
+				jedis.srem(key(WORKERS), workerName);
+				jedis.del(
+					key(WORKER, workerName),
+					key(WORKER, workerName, STARTED),
+					key(STAT, FAILED, workerName),
+					key(STAT, PROCESSED, workerName));
+				return null;
+			}
+		});
+	}
 }


### PR DESCRIPTION
I've added a removeWorker method on the WorkerInfoDAO to support the high-level concept of pruning workers without knowing what it means to prune workers. The implementation of when the prune workers is left for the user.

It does not look like there are tests around DAOs so I just committed the implementation.
