### PR TITLE
Worker implementation that will exit if all queues are empty for a set number of polling loops

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/WorkerExitOnEmpty.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerExitOnEmpty.java
@@ -1,0 +1,70 @@
+package net.greghaines.jesque.worker;
+
+import static net.greghaines.jesque.utils.ResqueConstants.QUEUE;
+import static net.greghaines.jesque.worker.WorkerEvent.WORKER_POLL;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import net.greghaines.jesque.Config;
+import net.greghaines.jesque.Job;
+import net.greghaines.jesque.json.ObjectMapperFactory;
+import net.greghaines.jesque.utils.JesqueUtils;
+
+public class WorkerExitOnEmpty extends WorkerImpl {
+    private int maxLoopsOnEmptyQueues;
+
+    public WorkerExitOnEmpty(Config config, Collection<String> queues, Map<String, ? extends Class<?>> jobTypes) {
+        this(config, queues, jobTypes, 3);
+    }
+
+    public WorkerExitOnEmpty(Config config, Collection<String> queues, Map<String, ? extends Class<?>> jobTypes,
+        int maxLoopsOnEmptyQueues) {
+        super(config, queues, jobTypes);
+        this.maxLoopsOnEmptyQueues = maxLoopsOnEmptyQueues;
+    }
+
+    /* (non-Javadoc)
+     * @see net.greghaines.jesque.worker.WorkerImpl#poll()
+     * Exists if all queues are empty maxLoopOnEmptyQueues times
+     */
+    @Override
+    protected void poll() {
+        int missCount = 0;
+        String curQueue = null;
+        int allQueuesEmptyCount = 0;
+
+        while (WorkerState.RUNNING.equals(this.state.get())) {
+            try {
+                renameThread("Waiting for " + JesqueUtils.join(",", this.queueNames));
+                curQueue = this.queueNames.poll(emptyQueueSleepTime, TimeUnit.MILLISECONDS);
+                if (curQueue != null) {
+                    this.queueNames.add(curQueue); // Rotate the queues
+                    checkPaused();
+                    if (WorkerState.RUNNING.equals(this.state.get())) // Might have been waiting in poll()/checkPaused() for a while
+                    {
+                        this.listenerDelegate.fireEvent(WORKER_POLL, this, curQueue, null, null, null, null);
+                        final String payload = this.jedis.lpop(key(QUEUE, curQueue));
+                        if (payload != null) {
+                            final Job job = ObjectMapperFactory.get().readValue(payload, Job.class);
+                            process(job, curQueue);
+                            missCount = 0;
+                            allQueuesEmptyCount = 0;
+                        } else if ((++missCount >= this.queueNames.size()) && WorkerState.RUNNING.equals(this.state.get())) { // Keeps worker from busy-spinning on empty queues
+                            missCount = 0;
+                            Thread.sleep(emptyQueueSleepTime);
+                            allQueuesEmptyCount++;
+                        }
+
+                        if (allQueuesEmptyCount >= maxLoopsOnEmptyQueues) {
+                            end(false); // sets state to SHUTDOWN which will break the loop
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                recoverFromException(curQueue, e);
+            }
+        }
+    }
+}

--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -127,11 +127,11 @@ public class WorkerImpl implements Worker
 
 	protected final Jedis jedis;
 	protected final String namespace;
-	private final BlockingDeque<String> queueNames;
+	protected final BlockingDeque<String> queueNames;
 	private final ConcurrentMap<String,Class<?>> jobTypes = new ConcurrentHashMap<String,Class<?>>();
 	private final String name;
 	protected final WorkerListenerDelegate listenerDelegate = new WorkerListenerDelegate();
-	private final AtomicReference<WorkerState> state =
+	protected final AtomicReference<WorkerState> state =
 		new AtomicReference<WorkerState>(WorkerState.NEW);
 	private final AtomicBoolean paused = new AtomicBoolean(false);
 	private final long workerId = workerCounter.getAndIncrement();


### PR DESCRIPTION
-This is useful if you have more queues that you want active workers for at one time, and you don't want workers working multiple queues.
-Essentially once a worker starts a queue you want that queue worked to exhaustion, then you want that worker to die, and to start up another worker on a new queue.

Hi Greg,

You are welcome to include this change in jesque.  I couldn't see an easy way to test this in your testing framework.  I have incorporated testing in our application, but I can't get any more time from work to figure out how to fit this into your tests.

Thanks,

Timothy
