### PR TITLE
Thread renaming removed

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/WorkerExitOnEmpty.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerExitOnEmpty.java
@@ -37,7 +37,9 @@ public class WorkerExitOnEmpty extends WorkerImpl {
 
         while (WorkerState.RUNNING.equals(this.state.get())) {
             try {
-                renameThread("Waiting for " + JesqueUtils.join(",", this.queueNames));
+                if(debugThreadNameChange) {
+                    renameThread("Waiting for " + JesqueUtils.join(",", this.queueNames));
+                }
                 curQueue = this.queueNames.poll(emptyQueueSleepTime, TimeUnit.MILLISECONDS);
                 if (curQueue != null) {
                     this.queueNames.add(curQueue); // Rotate the queues

--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -104,6 +104,7 @@ public class WorkerImpl implements Worker
 	protected static final long emptyQueueSleepTime = 500; // 500 ms
 	private static final long reconnectSleepTime = 5000; // 5s
 	private static final int reconnectAttempts = 120; // Total time: 10min
+    protected static final boolean debugThreadNameChange = false; // set the thread name to the message for debugging
 
 	/**
 	 * Verify that the given queues are all valid.
@@ -447,7 +448,9 @@ public class WorkerImpl implements Worker
 		{
 			try
 			{
-				renameThread("Waiting for " + JesqueUtils.join(",", this.queueNames));
+                if(debugThreadNameChange) {
+				    renameThread("Waiting for " + JesqueUtils.join(",", this.queueNames));
+                }
 				curQueue = this.queueNames.poll(emptyQueueSleepTime, TimeUnit.MILLISECONDS);
 				if (curQueue != null)
 				{
@@ -553,7 +556,9 @@ public class WorkerImpl implements Worker
 	protected void process(final Job job, final String curQueue)
 	{
 		this.listenerDelegate.fireEvent(JOB_PROCESS, this, curQueue, job, null, null, null);
-		renameThread("Processing " + curQueue + " since " + System.currentTimeMillis());
+        if(debugThreadNameChange) {
+    		renameThread("Processing " + curQueue + " since " + System.currentTimeMillis());
+        }
 		try
 		{
 			final Class<?> clazz = this.jobTypes.get(job.getClassName());


### PR DESCRIPTION
Hi Greg.  Thanks for Jesque, we've gotten a lot of awesome use from it.  

I've been looking at some profiling information today and it turns out that thread renaming incurs an unreasonable mount of overhead when done at scale.  We're seeing it done several hundred thousand to millions of times and this ends up taking 6-8% of total CPU usage for our work and an even larger percentage of the jesque worker code (I think 20-30%).  

I'm hoping you'll take this commit that removes thread renaming.  I understand it can be useful for monitoring and debugging, but given the performance implications I thought it best to remove it altogether.  Your thoughts?
- Chris
