### PR TITLE
Adding a callback interface for customizing job instances

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/ActionCustomizer.java
+++ b/src/main/java/net/greghaines/jesque/worker/ActionCustomizer.java
@@ -1,0 +1,16 @@
+package net.greghaines.jesque.worker;
+
+/**
+ * A callback that enables the application of customizations to newly-instantiated actions
+ *
+ * @author Noam Y. Tenne
+ */
+public interface ActionCustomizer
+{
+    /**
+     * Called after the construction of an action and prior to its execution
+     *
+     * @param actionInstance To-be executed action instance
+     */
+    void customize(Object actionInstance);
+}

--- a/src/main/java/net/greghaines/jesque/worker/WorkerExitOnEmpty.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerExitOnEmpty.java
@@ -38,7 +38,7 @@ public class WorkerExitOnEmpty extends WorkerImpl
 	public WorkerExitOnEmpty(final Config config, final Collection<String> queues,
 			final Map<String,? extends Class<?>> jobTypes, final int maxLoopsOnEmptyQueues)
 	{
-		super(config, queues, jobTypes);
+		super(config, queues, jobTypes, null);
 		this.maxLoopsOnEmptyQueues = maxLoopsOnEmptyQueues;
 	}
 

--- a/src/main/java/net/greghaines/jesque/worker/WorkerImplFactory.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImplFactory.java
@@ -53,6 +53,6 @@ public class WorkerImplFactory implements Callable<WorkerImpl>
 	 */
 	public WorkerImpl call()
 	{
-		return new WorkerImpl(this.config, this.queues, this.jobTypes);
+		return new WorkerImpl(this.config, this.queues, this.jobTypes, null);
 	}
 }

--- a/src/test/java/net/greghaines/jesque/ClientBeforeWorkerTest.java
+++ b/src/test/java/net/greghaines/jesque/ClientBeforeWorkerTest.java
@@ -70,7 +70,8 @@ public class ClientBeforeWorkerTest
 		}
 		
 		// Create and start worker
-		final Worker worker = new WorkerImpl(config, Arrays.asList(testQueue), map(entry("TestAction", TestAction.class)));
+		final Worker worker = new WorkerImpl(config, Arrays.asList(testQueue), map(entry("TestAction", TestAction.class)),
+                null);
 		final Thread workerThread = new Thread(worker);
 		workerThread.start();
 		try

--- a/src/test/java/net/greghaines/jesque/CustomizableAction.java
+++ b/src/test/java/net/greghaines/jesque/CustomizableAction.java
@@ -1,0 +1,20 @@
+package net.greghaines.jesque;
+
+/**
+ * @author Noam Y. Tenne
+ */
+public class CustomizableAction implements Runnable {
+
+    private boolean failAction = true;
+
+    @Override
+    public void run() {
+        if (failAction) {
+            throw new RuntimeException("Failed to run customizable action");
+        }
+    }
+
+    public void setFailAction(boolean failAction) {
+        this.failAction = failAction;
+    }
+}

--- a/src/test/java/net/greghaines/jesque/CustomizableActionIntegrationTest.java
+++ b/src/test/java/net/greghaines/jesque/CustomizableActionIntegrationTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2011 Greg Haines
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.greghaines.jesque;
+
+import net.greghaines.jesque.worker.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static net.greghaines.jesque.TestUtils.createJedis;
+import static net.greghaines.jesque.utils.JesqueUtils.*;
+import static net.greghaines.jesque.utils.ResqueConstants.*;
+
+/**
+ * @author Noam Y. Tenne
+ */
+public class CustomizableActionIntegrationTest
+{
+	private static final Config config = new ConfigBuilder().build();
+	private static final String testQueue = "foo";
+	
+	@Before
+	public void resetRedis()
+	{
+		TestUtils.resetRedis(config);
+	}
+
+    @Test
+    public void testFailingCustomizableAction()
+    {
+		final Job job = new Job("CustomizableAction");
+		
+		doWork(Arrays.asList(job), map(entry("CustomizableAction", CustomizableAction.class)), null);
+		
+		final Jedis jedis = createJedis(config);
+		try
+		{
+			Assert.assertNull(jedis.get(createKey(config.getNamespace(), STAT, PROCESSED)));
+			Assert.assertEquals("1", jedis.get(createKey(config.getNamespace(), STAT, FAILED)));
+		}
+		finally
+		{
+			jedis.quit();
+		}
+	}
+
+    @Test
+    public void testSucceedingCustomizableAction()
+    {
+		final Job job = new Job("CustomizableAction");
+
+        ActionCustomizer customizer = new ActionCustomizer()
+        {
+            @Override
+            public void customize(Object actionInstance)
+            {
+                ((CustomizableAction) actionInstance).setFailAction(false);
+            }
+        };
+
+        doWork(Arrays.asList(job), map(entry("CustomizableAction", CustomizableAction.class)), customizer);
+
+		final Jedis jedis = createJedis(config);
+		try
+		{
+			Assert.assertEquals("1", jedis.get(createKey(config.getNamespace(), STAT, PROCESSED)));
+            Assert.assertNull(jedis.get(createKey(config.getNamespace(), STAT, FAILED)));
+        }
+		finally
+		{
+			jedis.quit();
+		}
+	}
+
+	private static void doWork(final List<Job> jobs, final Map<String,? extends Class<? extends Runnable>> jobTypes,
+			ActionCustomizer customizer)
+	{
+		final Worker worker = new WorkerImpl(config, Arrays.asList(testQueue), jobTypes, customizer);
+		final Thread workerThread = new Thread(worker);
+		workerThread.start();
+		try
+		{
+			TestUtils.enqueueJobs(testQueue, jobs, config);
+		}
+		finally
+		{
+			TestUtils.stopWorker(worker, workerThread);
+		}
+	}
+}

--- a/src/test/java/net/greghaines/jesque/InfiniteTest.java
+++ b/src/test/java/net/greghaines/jesque/InfiniteTest.java
@@ -51,13 +51,13 @@ public class InfiniteTest
 			TestUtils.enqueueJobs("bar", jobs, config);
 		}
 		final Worker worker = new WorkerImpl(config, Arrays.asList("foo0", "bar","baz"), 
-			map(entry("TestAction", TestAction.class), entry("FailAction", FailAction.class)));
+			map(entry("TestAction", TestAction.class), entry("FailAction", FailAction.class)), null);
 		final Thread workerThread = new Thread(worker);
 		workerThread.start();
 		
 		TestUtils.enqueueJobs("inf", Arrays.asList(new Job("InfiniteAction")), config);
 		final Worker worker2 = new WorkerImpl(config, Arrays.asList("inf"), 
-			map(entry("InfiniteAction", InfiniteAction.class)));
+			map(entry("InfiniteAction", InfiniteAction.class)), null);
 		final Thread workerThread2 = new Thread(worker2);
 		workerThread2.start();
 		
@@ -70,7 +70,7 @@ public class InfiniteTest
 	throws InterruptedException
 	{
 		final Worker worker = new WorkerImpl(config, Arrays.asList("foo"), 
-			map(entry("TestAction", TestAction.class), entry("FailAction", FailAction.class)));
+			map(entry("TestAction", TestAction.class), entry("FailAction", FailAction.class)), null);
 		final Thread workerThread = new Thread(worker);
 		workerThread.start();
 		

--- a/src/test/java/net/greghaines/jesque/IntegrationTest.java
+++ b/src/test/java/net/greghaines/jesque/IntegrationTest.java
@@ -253,7 +253,7 @@ public class IntegrationTest
 	private static void doWork(final List<Job> jobs, final Map<String,? extends Class<? extends Runnable>> jobTypes,
 			final WorkerListener listener, final WorkerEvent... events)
 	{
-		final Worker worker = new WorkerImpl(config, Arrays.asList(testQueue), jobTypes);
+		final Worker worker = new WorkerImpl(config, Arrays.asList(testQueue), jobTypes, null);
 		if (listener != null && events.length > 0)
 		{
 			worker.addListener(listener, events);


### PR DESCRIPTION
I've created this small fix that lets you apply changes to newly-instantiated actions; this is useful in cases where you might want to inject the action with contexts local to the action executor
