### PR TITLE
Allow a WorkerImpl subclass to validate the jobType

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -369,18 +369,7 @@ public class WorkerImpl implements Worker
 
 	public void addJobType(final String jobName, final Class<?> jobType)
 	{
-		if (jobName == null)
-		{
-			throw new IllegalArgumentException("jobName must not be null");
-		}
-		if (jobType == null)
-		{
-			throw new IllegalArgumentException("jobType must not be null");
-		}
-		if (!(Runnable.class.isAssignableFrom(jobType)) && !(Callable.class.isAssignableFrom(jobType)))
-		{
-			throw new IllegalArgumentException("jobType must implement either Runnable or Callable: " + jobType);
-		}
+		checkJobType(jobName, jobType);
 		this.jobTypes.put(jobName, jobType);
 	}
 
@@ -800,19 +789,35 @@ public class WorkerImpl implements Worker
 		}
 		for (final Entry<String,? extends Class<?>> entry : jobTypes.entrySet())
 		{
-			if (entry.getKey() == null)
+			try
 			{
-				throw new IllegalArgumentException("jobType's keys must not be null: " + jobTypes);
+				checkJobType( entry.getKey(), entry.getValue() );
 			}
-			final Class<?> jobType = entry.getValue();
-			if (jobType == null)
+			catch(IllegalArgumentException iae)
 			{
-				throw new IllegalArgumentException("jobType's values must not be null: " + jobTypes);
+				throw new IllegalArgumentException("jobTypes contained invalid value", iae);
 			}
-			if (!(Runnable.class.isAssignableFrom(jobType)) && !(Callable.class.isAssignableFrom(jobType)))
-			{
-				throw new IllegalArgumentException("jobType's values must implement either Runnable or Callable: " + jobTypes);
-			}
+		}
+	}
+
+	/**
+	 * determine if a job name and job type is valid
+	 * @param jobName the name of the job
+	 * @param jobType the class of the job
+	 */
+	protected void checkJobType(final String jobName, final Class<?> jobType)
+	{
+		if (jobName == null)
+		{
+			throw new IllegalArgumentException("jobName must not be null");
+		}
+		if (jobType == null)
+		{
+			throw new IllegalArgumentException("jobType must not be null");
+		}
+		if (!(Runnable.class.isAssignableFrom(jobType)) && !(Callable.class.isAssignableFrom(jobType)))
+		{
+			throw new IllegalArgumentException("jobType must implement either Runnable or Callable: " + jobType);
 		}
 	}
 


### PR DESCRIPTION
The Grails Jesque plugin cannot use Jesque 1.3.0 out of the box because of issue 24 (https://github.com/michaelcameron/grails-jesque/issues/24). In short, I had to override the addJobType early on just to loosen the requirement that the jobType class is `Runnable` or `Callable` so the job types can just be POGOs and we can follow convention over configuration.

With changes in Jesque 1.3.0 the constructor changed from adding jobTypes directly to the JobType map to calling `addJobType`. This started a cascade of code that leads to the GrailsWorkerImpl trying to add directly to the jobType map. I think it turns out my implementation of `addJobType` would never have worked, because it would have received the unmodifiable version returned by `WorkerImpl.getJobTypes`, but in all cases the jobTypes were set in the constructor (and thus worked in jesque < 1.3.0).
