### PR TITLE
Implement failover modules. (failover queue/worker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ workerThread.start();
 try { Thread.sleep(5000); } catch (Exception e){} // Give ourselves time to process
 worker.end(true);
 try { workerThread.join(); } catch (Exception e){ e.printStackTrace(); }
+
+// Start a failoverWorker to failback from the failoverQueue
+final Worker failoverWorker = new FailoverWorkerImpl(config);
+final Thread failoverWorkerThread = new Thread(failoverWorker);
+failoverWorkerThread.start();
+
 ```
 
 For more usage examples check the tests. The tests require that Redis is running on localhost:6379.

--- a/src/main/java/net/greghaines/jesque/Config.java
+++ b/src/main/java/net/greghaines/jesque/Config.java
@@ -29,13 +29,69 @@ public class Config implements Serializable {
     
     private static final long serialVersionUID = -6638770587683679373L;
 
-    private final String host;
-    private final int port;
-    private final int timeout;
-    private final String password;
-    private final String namespace;
-    private final int database;
-
+    protected final String host;
+    protected final int port;
+    protected final int timeout;
+    protected final String password;
+    protected final String namespace;
+    protected final int database;
+    
+    private boolean failoverEnabled;
+    private int heartbeatTimeoutPeriodSec;
+    private int heartbeatTransmissionPeriodSec;
+    private String failoverQueueName;
+    private boolean isFailoverDataKeyContainsUUID;
+    
+    /**
+     * Using a ConfigBuilder is recommended...
+     * 
+     * @param host
+     *            the Reds hostname
+     * @param port
+     *            the Redis port number
+     * @param timeout
+     *            the Redis connection timeout
+     * @param namespace
+     *            the Redis namespace to prefix keys with
+     * @param database
+     *            the Redis database to use
+     * @param failoverEnabled
+     *            failoverEnabled
+     * @param heartbeatTimeoutPeriodSec
+     *            heartbeatTimeoutPeriodSec
+     * @param heartbeatTransmissionPeriodSec
+     *            heartbeatTransmissionPeriodSec
+     * @param failoverQueueName
+     *            failoverQueueName
+     * @param isFailoverDataKeyContainsUUID
+     *            isFailoverDataKeyContainsUUID
+     * @see ConfigBuilder
+     */
+    public Config(final String host, final int port, final int timeout,
+            final String password, final String namespace, final int database,
+            final boolean failoverEnabled, final int heartbeatTimeoutPeriodSec,
+            final int heartbeatTransmissionPeriodSec, final String failoverQueueName,
+            final boolean isFailoverDataKeyContainsUUID) {
+        this(host, port, timeout, password, namespace, database);
+        if (heartbeatTimeoutPeriodSec < 1) {
+            throw new IllegalArgumentException("heartbeatTimeoutPeriodSec must not be negative or zero: "
+                    + heartbeatTimeoutPeriodSec);
+        }
+        if (heartbeatTimeoutPeriodSec <= heartbeatTransmissionPeriodSec) {
+            throw new IllegalArgumentException(
+                    "heartbeatTimeoutPeriodSec must greater than heartbeatTransmissionPeriodSec: "
+                            + heartbeatTransmissionPeriodSec);
+        }
+        if (failoverQueueName == null || "".equals(failoverQueueName)) {
+            throw new IllegalArgumentException(
+                    "failoverQueueName must not be null or empty: " + failoverQueueName);
+        }
+        this.failoverEnabled = failoverEnabled;
+        this.heartbeatTimeoutPeriodSec = heartbeatTimeoutPeriodSec;
+        this.heartbeatTransmissionPeriodSec = heartbeatTransmissionPeriodSec;
+        this.failoverQueueName = failoverQueueName;
+        this.isFailoverDataKeyContainsUUID = isFailoverDataKeyContainsUUID;
+    }
     /**
      * Using a ConfigBuilder is recommended...
      * 
@@ -125,6 +181,41 @@ public class Config implements Serializable {
     }
 
     /**
+     * @return true if failover is enabled
+     */
+    public boolean isFailoverEnabled() {
+        return failoverEnabled;
+    }
+    
+    /**
+     * @return heartbeat timeout value in seconds for failover detection
+     */
+    public int getHeartbeatTimeoutPeriodSec() {
+        return heartbeatTimeoutPeriodSec;
+    }
+    
+    /**
+     * @return heartebeat interval in seconds for failover detection
+     */
+    public int getHeartbeatTransmissionPeriodSec() {
+        return heartbeatTransmissionPeriodSec;
+    }
+    
+    /**
+     * @return the queue contains heatbeatTimeout-value and key of the redundant data pair for failover
+     */
+    public String getFailoverQueueName() {
+        return failoverQueueName;
+    }    
+
+    /**
+     * @return true if key of redundant data contains uuid to guarantee uniqueness
+     */
+    public boolean isFailoverDataKeyContainsUUID() {
+        return isFailoverDataKeyContainsUUID;
+    }
+    
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -144,6 +235,12 @@ public class Config implements Serializable {
         result = prime * result + ((this.namespace == null) ? 0 : this.namespace.hashCode());
         result = prime * result + this.port;
         result = prime * result + this.timeout;
+        
+        result = prime * result + Boolean.toString(failoverEnabled).hashCode();
+        result = prime * result + this.heartbeatTimeoutPeriodSec;
+        result = prime * result + this.heartbeatTransmissionPeriodSec;
+        result = prime * result + ((this.failoverQueueName == null) ? 0 : this.failoverQueueName.hashCode());
+        result = prime * result + Boolean.toString(isFailoverDataKeyContainsUUID).hashCode();
         return result;
     }
 
@@ -161,7 +258,12 @@ public class Config implements Serializable {
                     && (this.port == other.port)
                     && (this.timeout == other.timeout)
                     && JesqueUtils.nullSafeEquals(this.host, other.host)
-                    && JesqueUtils.nullSafeEquals(this.namespace, other.namespace));
+                    && JesqueUtils.nullSafeEquals(this.namespace, other.namespace))
+                    && (this.failoverEnabled == other.failoverEnabled)
+                    && (this.heartbeatTimeoutPeriodSec == other.heartbeatTimeoutPeriodSec)
+                    && (this.heartbeatTransmissionPeriodSec == other.heartbeatTransmissionPeriodSec)
+                    && JesqueUtils.nullSafeEquals(this.failoverQueueName, other.failoverQueueName)
+                    && (this.isFailoverDataKeyContainsUUID == other.isFailoverDataKeyContainsUUID);
         }
         return equal;
     }

--- a/src/main/java/net/greghaines/jesque/ConfigBuilder.java
+++ b/src/main/java/net/greghaines/jesque/ConfigBuilder.java
@@ -39,7 +39,18 @@ public class ConfigBuilder implements Serializable {
     public static final String DEFAULT_NAMESPACE = "resque";
     /** 0 */
     public static final int DEFAULT_DATABASE = 0;
-
+    
+    /** true */
+    public static final boolean DEFAULT_FAILOVER_ENABLED = true;
+    /** 130 */
+    public static final int DEFAULT_HEARTBEAT_TIMEOUT_PERIOD_SEC = 130;
+    /** 60 */
+    public static final int DEFAULT_HEARTBEAT_TRANSMISSION_PERIOD_SEC = 60;
+    /** FOQ */
+    public static final String DEFAULT_FAILOVER_QUEUE = "FOQ";
+    /** false */
+    public static final boolean DEFAULT_IS_FAILOVER_DATA_KEY_CONTAINS_UUID = false;
+    
     /**
      * @return a Config with all the default values set
      */
@@ -54,6 +65,12 @@ public class ConfigBuilder implements Serializable {
     private String namespace = DEFAULT_NAMESPACE;
     private int database = DEFAULT_DATABASE;
 
+    private boolean failoverEnabled = DEFAULT_FAILOVER_ENABLED;
+    private int heartbeatTimeoutPeriodSec = DEFAULT_HEARTBEAT_TIMEOUT_PERIOD_SEC;
+    private int heartbeatTransmissionPeriodSec = DEFAULT_HEARTBEAT_TRANSMISSION_PERIOD_SEC;
+    private String failoverQueueName = DEFAULT_FAILOVER_QUEUE;
+    private boolean isFailoverDataKeyContainsUUID = DEFAULT_IS_FAILOVER_DATA_KEY_CONTAINS_UUID;
+    
     /**
      * No-arg constructor.
      */
@@ -77,6 +94,11 @@ public class ConfigBuilder implements Serializable {
         this.timeout = startingPoint.getTimeout();
         this.namespace = startingPoint.getNamespace();
         this.database = startingPoint.getDatabase();
+        this.failoverEnabled = startingPoint.isFailoverEnabled();
+        this.heartbeatTimeoutPeriodSec = startingPoint.getHeartbeatTimeoutPeriodSec();
+        this.heartbeatTransmissionPeriodSec = startingPoint.getHeartbeatTransmissionPeriodSec();
+        this.failoverQueueName = startingPoint.getFailoverQueueName();
+        this.isFailoverDataKeyContainsUUID = startingPoint.isFailoverDataKeyContainsUUID();
     }
 
     /**
@@ -169,11 +191,85 @@ public class ConfigBuilder implements Serializable {
         this.database = database;
         return this;
     }
-
+    
+    /**
+     * Configs created by this ConfigBuilder will have the given failoverEnabled.
+     * 
+     * @param failoverEnabled
+     *            failoverEnabled
+     * @return this ConfigBuilder
+     */
+    public ConfigBuilder withFailoverEnabled(final boolean failoverEnabled) {
+        this.failoverEnabled = failoverEnabled;
+        return this;
+    }
+    
+    /**
+     * Configs created by this ConfigBuilder will use the given heartbeatTimeoutPeriodSec.
+     * 
+     * @param heartbeatTimeoutPeriodSec
+     *            heartbeatTimeoutPeriodSec
+     * @return this ConfigBuilder
+     */
+    public ConfigBuilder withHeartbeatTimeoutPeriodSec(final int heartbeatTimeoutPeriodSec) {
+        if (heartbeatTimeoutPeriodSec < 1) {
+            throw new IllegalArgumentException(
+                    "heartbeatTimeoutPeriodMs must not be negative or zero: " + heartbeatTimeoutPeriodSec);
+        }
+        this.heartbeatTimeoutPeriodSec = heartbeatTimeoutPeriodSec;
+        return this;
+    }
+    
+    /**
+     * Configs created by this ConfigBuilder will use the given heartbeatTransmissionPeriodSec.
+     * 
+     * @param heartbeatTransmissionPeriodSec
+     *            heartbeatTransmissionPeriodSec
+     * @return this ConfigBuilder
+     */
+    public ConfigBuilder withHeartbeatTransmissionPeriodSec(final int heartbeatTransmissionPeriodSec) {
+        if (heartbeatTransmissionPeriodSec < 1) {
+            throw new IllegalArgumentException(""
+                    + "heartbeatTransmissionPeriodSec must not be negative or zero: "
+                    + heartbeatTransmissionPeriodSec);
+        }
+        this.heartbeatTransmissionPeriodSec = heartbeatTransmissionPeriodSec;
+        return this;
+    }
+    
+    /**
+     * Configs created by this ConfigBuilder will have the given failOverQueueName.
+     * 
+     * @param failoverQueueName
+     *            failoverQueueName
+     * @return this ConfigBuilder
+     */
+    public ConfigBuilder withFailoverQueueName(final String failoverQueueName) {
+        if (failoverQueueName == null || "".equals(failoverQueueName)) {
+            throw new IllegalArgumentException("failoverQueueName must not be null or empty: " + failoverQueueName);
+        }
+        this.failoverQueueName = failoverQueueName;
+        return this;
+    }
+    
+    /**
+     * Configs created by this ConfigBuilder will have the given isFailoverDataKeyContainsUUID.
+     * 
+     * @param isFailoverDataKeyContainsUUID
+     *            isFailoverDataKeyContainsUUID
+     * @return this ConfigBuilder
+     */
+    public ConfigBuilder withFailoverDataKeyContainsUUID(final boolean isFailoverDataKeyContainsUUID) {
+        this.isFailoverDataKeyContainsUUID = isFailoverDataKeyContainsUUID;
+        return this;
+    }
+        
     /**
      * @return a new Config initialized with the current values
      */
     public Config build() {
-        return new Config(this.host, this.port, this.timeout, this.password, this.namespace, this.database);
+        return new Config(this.host, this.port, this.timeout, this.password, this.namespace, this.database,
+                this.failoverEnabled, this.heartbeatTimeoutPeriodSec, this.heartbeatTransmissionPeriodSec,
+                this.failoverQueueName, this.isFailoverDataKeyContainsUUID);
     }
 }

--- a/src/main/java/net/greghaines/jesque/ConfigFO.java
+++ b/src/main/java/net/greghaines/jesque/ConfigFO.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2011 Greg Haines
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.greghaines.jesque;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+import net.greghaines.jesque.utils.JesqueUtils;
+
+/**
+ * An immutable configuration bean for use with the failover modules.
+ * 
+ * @author Greg Haines
+ * @author Heebyung
+ * @see ConfigFOBuilder
+ */
+public class ConfigFO extends Config implements Serializable {
+    
+    private static final long serialVersionUID = 832559337030832779L;
+    
+    private int emptyFailoverQueueSleepTimeSec;
+    private Collection<String> failoverQueues;
+
+    public ConfigFO(final String host, final int port, final int timeout, final String password, final String namespace, final int database,
+            final int emptyFailoverQueueSleepTimeSec, final Collection<String> failoverQueues) {
+        super(host, port, timeout, password, namespace, database);
+        if (emptyFailoverQueueSleepTimeSec < 1) {
+            throw new IllegalArgumentException(
+                    "emptyFailoverQueueSleepTimeMs must not be negative or zero: "
+                            + emptyFailoverQueueSleepTimeSec);
+        }
+        this.emptyFailoverQueueSleepTimeSec = emptyFailoverQueueSleepTimeSec;
+        this.failoverQueues = failoverQueues;
+    }
+
+    /**
+     * @return the Redis hostname
+     */
+    public String getHost() {
+        return this.host;
+    }
+
+    /**
+     * @return the Redis port number
+     */
+    public int getPort() {
+        return this.port;
+    }
+
+    /**
+     * @return the Redis connection timeout
+     */
+    public int getTimeout() {
+        return this.timeout;
+    }
+
+    /**
+     * @return the Redis password
+     */
+    public String getPassword() {
+        return this.password;
+    }
+
+    /**
+     * @return the Redis namespace to prefix keys with
+     */
+    public String getNamespace() {
+        return this.namespace;
+    }
+
+    /**
+     * @return the Redis database to use
+     */
+    public int getDatabase() {
+        return this.database;
+    }
+
+    /**
+     * @return the Redis protocol URI this Config will connect to
+     */
+    public String getURI() {
+        return "redis://" + this.host + ":" + this.port + "/" + this.database;
+    }
+
+    public int getEmptyFailoverQueueSleepTimeSec() {
+        return emptyFailoverQueueSleepTimeSec;
+    }
+    
+    public Collection<String> getFailoverQueues() {
+        return failoverQueues;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "<" + getURI() + " namespace=" + this.namespace + " timeout=" + this.timeout + ">";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + this.database;
+        result = prime * result + ((this.host == null) ? 0 : this.host.hashCode());
+        result = prime * result + ((this.namespace == null) ? 0 : this.namespace.hashCode());
+        result = prime * result + this.port;
+        result = prime * result + this.timeout;
+        result = prime * result + this.emptyFailoverQueueSleepTimeSec;
+        result = prime * result + ((this.failoverQueues == null) ? 0 : this.failoverQueues.hashCode());
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        boolean equal = false;
+        if (this == obj) {
+            equal = true;
+        } else if (obj instanceof ConfigFO) {
+            final ConfigFO other = (ConfigFO) obj;
+            equal = ((this.database == other.database)
+                    && (this.port == other.port)
+                    && (this.timeout == other.timeout)
+                    && JesqueUtils.nullSafeEquals(this.host, other.host)
+                    && JesqueUtils.nullSafeEquals(this.namespace, other.namespace))
+                    && (this.emptyFailoverQueueSleepTimeSec == other.emptyFailoverQueueSleepTimeSec)
+                    && JesqueUtils.nullSafeEquals(this.failoverQueues, other.failoverQueues);
+        }
+        return equal;
+    }
+}

--- a/src/main/java/net/greghaines/jesque/ConfigFOBuilder.java
+++ b/src/main/java/net/greghaines/jesque/ConfigFOBuilder.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2011 Greg Haines
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.greghaines.jesque;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * A fluent-style builder for {@link ConfigFO}s.
+ * 
+ * @author Greg Haines
+ * @author Heebyung
+ * @see ConfigFO
+ */
+public class ConfigFOBuilder implements Serializable {
+    
+    private static final long serialVersionUID = -4815539606528776604L;
+    
+    /** localhost */
+    public static final String DEFAULT_HOST = "localhost";
+    /** 6379 */
+    public static final int DEFAULT_PORT = 6379;
+    /** 5 seconds */
+    public static final int DEFAULT_TIMEOUT = 5000;
+    /** null */
+    public static final String DEFAULT_PASSWORD = null;
+    /** All resque clients use "resque" by default */
+    public static final String DEFAULT_NAMESPACE = "resque";
+    /** 0 */
+    public static final int DEFAULT_DATABASE = 0;
+    /** 10 */
+    public static final int DEFAULT_EMPTY_FAILOVER_QUEUE_SLEEP_TIME_SEC = 10;
+    
+    /**
+     * @return a ConfigFO with all the default values set
+     */
+    public static ConfigFO getDefaultConfig() {
+        return new ConfigFOBuilder().build();
+    }
+
+    private String host = DEFAULT_HOST;
+    private int port = DEFAULT_PORT;
+    private int timeout = DEFAULT_TIMEOUT;
+    private String password = DEFAULT_PASSWORD;
+    private String namespace = DEFAULT_NAMESPACE;
+    private int database = DEFAULT_DATABASE;
+
+    private int emptyFailoverQueueSleepTimeSec = DEFAULT_EMPTY_FAILOVER_QUEUE_SLEEP_TIME_SEC;
+    private Collection<String> failoverQueues;
+    /**
+     * No-arg constructor.
+     */
+    public ConfigFOBuilder() {
+        failoverQueues = new ArrayList<String>();
+        failoverQueues.add(ConfigBuilder.DEFAULT_FAILOVER_QUEUE);        
+    }
+
+    /**
+     * Create a new ConfigBuilder using an existing Config as the starting
+     * point.
+     * 
+     * @param startingPoint
+     *            the Config instance to copy the values from
+     */
+    public ConfigFOBuilder(final Config startingPoint) {
+        this();
+        if (startingPoint == null) {
+            throw new IllegalArgumentException("startingPoint must not be null");
+        }
+        this.host = startingPoint.getHost();
+        this.port = startingPoint.getPort();
+        this.timeout = startingPoint.getTimeout();
+        this.namespace = startingPoint.getNamespace();
+        this.database = startingPoint.getDatabase();
+    }
+    
+    /**
+     * Create a new ConfigBuilder using an existing Config as the starting
+     * point.
+     * 
+     * @param startingPoint
+     *            the Config instance to copy the values from
+     */
+    public ConfigFOBuilder(final ConfigFO startingPoint) {
+        this((Config)startingPoint);
+        if (startingPoint == null) {
+            throw new IllegalArgumentException("startingPoint must not be null");
+        }
+        this.emptyFailoverQueueSleepTimeSec = startingPoint.getEmptyFailoverQueueSleepTimeSec();
+        this.failoverQueues = startingPoint.getFailoverQueues();
+    }
+
+    /**
+     * Configs created by this ConfigBuilder will have the given Redis hostname.
+     * 
+     * @param host
+     *            the Redis hostname
+     * @return this ConfigBuilder
+     */
+    public ConfigFOBuilder withHost(final String host) {
+        if (host == null || "".equals(host)) {
+            throw new IllegalArgumentException("host must not be null or empty: " + host);
+        }
+        this.host = host;
+        return this;
+    }
+
+    /**
+     * Configs created by this ConfigBuilder will have the given Redis port
+     * number.
+     * 
+     * @param port
+     *            the Redis port number
+     * @return this ConfigBuilder
+     */
+    public ConfigFOBuilder withPort(final int port) {
+        if (port < 1 || port > 65535) {
+            throw new IllegalArgumentException("post must be a valid port in the range 1-65535: " + port);
+        }
+        this.port = port;
+        return this;
+    }
+
+    /**
+     * Configs created by this ConfigBuilder will have the given Redis
+     * connection timeout.
+     * 
+     * @param timeout
+     *            the Redis connection timeout
+     * @return this ConfigBuilder
+     */
+    public ConfigFOBuilder withTimeout(final int timeout) {
+        if (timeout < 0) {
+            throw new IllegalArgumentException("timeout must not be negative: " + timeout);
+        }
+        this.timeout = timeout;
+        return this;
+    }
+
+    /**
+     * Configs created by this ConfigBuilder will authenticate with the given
+     * Redis password.
+     * 
+     * @param password
+     *            the Redis password
+     * @return this ConfigBuilder
+     */
+    public ConfigFOBuilder withPassword(final String password) {
+        this.password = password;
+        return this;
+    }
+
+    /**
+     * Configs created by this ConfigBuilder will have the given Redis namespace
+     * to prefix keys with.
+     * 
+     * @param namespace
+     *            the Redis namespace to prefix keys with
+     * @return this ConfigBuilder
+     */
+    public ConfigFOBuilder withNamespace(final String namespace) {
+        if (namespace == null || "".equals(namespace)) {
+            throw new IllegalArgumentException("namespace must not be null or empty: " + namespace);
+        }
+        this.namespace = namespace;
+        return this;
+    }
+
+    /**
+     * Configs created by this ConfigBuilder will use the given Redis database.
+     * 
+     * @param database
+     *            the Redis database to use
+     * @return this ConfigBuilder
+     */
+    public ConfigFOBuilder withDatabase(final int database) {
+        if (database < 0) {
+            throw new IllegalArgumentException("database must not be negative: " + database);
+        }
+        this.database = database;
+        return this;
+    }    
+    
+    /**
+     * Configs created by this ConfigBuilder will have the given emptyFailoverQueueSleepTimeMs
+     * 
+     * @param emptyFailoverQueueSleepTimeSec
+     *            emptyFailoverQueueSleepTimeSec
+     * @return this ConfigBuilder
+     */
+    public ConfigFOBuilder withEmptyFailoverQueueSleepTimeSec(final int emptyFailoverQueueSleepTimeSec) {
+        if (emptyFailoverQueueSleepTimeSec < 1) {
+            throw new IllegalArgumentException(""
+                    + "EmptyFailoverQueueSleepTimeSec must not be negative or zero: "
+                    + emptyFailoverQueueSleepTimeSec);
+        }
+        this.emptyFailoverQueueSleepTimeSec = emptyFailoverQueueSleepTimeSec;
+        return this;
+    }
+    
+    /**
+     * Configs created by this ConfigBuilder will have the given emptyFailoverQueueSleepTimeMs
+     * 
+     * @param failoverQueues
+     *            failoverQueues
+     * @return this ConfigBuilder
+     */
+    public ConfigFOBuilder withFailoverQueues(Collection<String> failoverQueues) {
+        if (failoverQueues == null || failoverQueues.isEmpty()) {
+            throw new IllegalArgumentException(""
+                    + "failoverQueues must not be null or empty: "
+                    + failoverQueues);
+        }
+        this.failoverQueues = failoverQueues;
+        return this;
+    }
+    
+    /**
+     * @return a new Config initialized with the current values
+     */
+    public ConfigFO build() {
+        return new ConfigFO(this.host, this.port, this.timeout, this.password, this.namespace, this.database,
+                this.emptyFailoverQueueSleepTimeSec, this.failoverQueues);
+    }
+}

--- a/src/main/java/net/greghaines/jesque/utils/ResqueConstants.java
+++ b/src/main/java/net/greghaines/jesque/utils/ResqueConstants.java
@@ -20,49 +20,148 @@ package net.greghaines.jesque.utils;
  * 
  * @author Greg Haines
  */
-public interface ResqueConstants {
+public final class ResqueConstants {
+    
+    private ResqueConstants() {
+        // restrict instantiation
+    }
     
     /**
      * ISO-8601 compliant format
      */
-    String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
     /**
      * For interoperability with php-resque
      */
-    String DATE_FORMAT_PHP = "EEE MMM dd HH:mm:ss z yyyy";
+    public static final String DATE_FORMAT_PHP = "EEE MMM dd HH:mm:ss z yyyy";
     /**
      * For interoperability with Resque (ruby)
      */
-    String DATE_FORMAT_RUBY_V1 = "yyyy-MM-dd HH:mm:ss Z";
+    public static final String DATE_FORMAT_RUBY_V1 = "yyyy-MM-dd HH:mm:ss Z";
     /**
      * For interoperability with Resque (ruby)
      */
-    String DATE_FORMAT_RUBY_V2 = "yyyy-MM-dd HH:mm:ss";
+    public static final String DATE_FORMAT_RUBY_V2 = "yyyy-MM-dd HH:mm:ss";
     /**
      * For interoperability with Resque (ruby)
      */
-    String DATE_FORMAT_RUBY_V3 = "yyyy/MM/dd HH:mm:ss Z";
+    public static final String DATE_FORMAT_RUBY_V3 = "yyyy/MM/dd HH:mm:ss Z";
     /**
      * For interoperability with Resque (ruby)
      */
-    String DATE_FORMAT_RUBY_V4 = "yyyy/MM/dd HH:mm:ss";
+    public static final String DATE_FORMAT_RUBY_V4 = "yyyy/MM/dd HH:mm:ss";
 
-    String JAVA_DYNAMIC_QUEUES = "JAVA_DYNAMIC_QUEUES";
+    public static final String JAVA_DYNAMIC_QUEUES = "JAVA_DYNAMIC_QUEUES";
+    public static final String FAILOVER_QUEUES = "FAILOVER_QUEUES";
 
-    String COLON = ":";
-    String FAILED = "failed";
-    String PROCESSED = "processed";
-    String QUEUE = "queue";
-    String QUEUES = "queues";
-    String STARTED = "started";
-    String STAT = "stat";
-    String WORKER = "worker";
-    String WORKERS = "workers";
-    String CHANNEL = "channel";
-    String INFLIGHT = "inflight";
+    public static final String COLON = ":";
+    public static final String FAILED = "failed";
+    public static final String PROCESSED = "processed";
+    public static final String QUEUE = "queue";
+    public static final String QUEUES = "queues";
+    public static final String FOQUEUES = "FOqueues";
+    public static final String STARTED = "started";
+    public static final String STAT = "stat";
+    public static final String WORKER = "worker";
+    public static final String WORKERS = "workers";
+    public static final String CHANNEL = "channel";
+    public static final String INFLIGHT = "inflight";
+    public static final String FAILOVER = "failover";    
+    
+    public static final String LPOP_FO = "lpop_fo";
+    public static final String HEARTBEAT_FO = "heartbeat_fo";
+    public static final String CLEANUP_FO = "cleanup_fo";
+    public static final String FAILBACK = "reaper_fo";
 
+    public static final String LPOP_FO_SCRIPT = new StringBuilderWithNewline()
+            .appendLine("local queue = KEYS[1]")
+            .appendLine("local foqueue = KEYS[2]")
+            .appendLine("local foworker = KEYS[3]")
+            .appendLine("local unixtime = KEYS[4]")
+            .appendLine("local job = redis.call('LPOP', queue)")
+            .appendLine("if job == false then\n  return nil;\nend")
+            .appendLine("redis.call('ZADD', foqueue, unixtime, foworker)")
+            .appendLine("redis.call('SET', foworker, job)")
+            .appendLine("return job")
+            .toString();
+
+    public static final String CLEANUP_FO_SCRIPT = new StringBuilderWithNewline()
+            .appendLine("local foqueue = KEYS[1]")
+            .appendLine("local foworker = KEYS[2]")
+            .appendLine("redis.call('ZREM', foqueue, foworker)")
+            .appendLine("redis.call('DEL', foworker)")
+            .toString();
+    
+    public static final String HEARTBEAT_FO_SCRIPT = new StringBuilderWithNewline()
+            .appendLine("local foqueue = KEYS[1]")
+            .appendLine("local foworker = KEYS[2]")
+            .appendLine("local unixtime = KEYS[3]")
+            .appendLine("local rank = redis.call('ZRANK', foqueue, foworker)")
+            .appendLine("if rank == false then")
+            .appendLine("  return nil;")
+            .appendLine("else")
+            .appendLine("  redis.call('ZADD', foqueue, unixtime, foworker)")
+            .appendLine("  return 0;")
+            .appendLine("end")
+            .toString();
+    
+    public static final String FAILBACK_SCRIPT = new StringBuilderWithNewline()
+            .appendLine("local foqueue = KEYS[1]")
+            .appendLine("local unixtime = KEYS[2]")
+            .appendLine("local foworker = redis.call('ZRANGEBYSCORE', foqueue, -1, unixtime, 'LIMIT', 0, 1)[1]")
+            .appendLine("if foworker == nil then return nil; end")
+            .appendLine("local job = redis.call('GET', foworker)")
+            .appendLine("if job == false then")
+            .appendLine("  redis.call('RPUSH', '#emptyfodata', foworker)")
+            .appendLine("  redis.call('ZREM', foqueue, foworker)")
+            .appendLine("  return 1;")
+            .appendLine("end")
+            .appendLine("local workerIdx = foworker:match('()'..','..'.*')")
+            .appendLine("if workerIdx == nil then")
+            .appendLine("  redis.call('RPUSH', '#wrongfodata', job)")
+            .appendLine("  redis.call('ZREM', foqueue, foworker)")
+            .appendLine("  redis.call('DEL', foworker)")
+            .appendLine("  return 2;")
+            .appendLine("end")
+            .appendLine("local postfix = string.sub(foworker, workerIdx+1, -1)")
+            .appendLine("local queueIdx = postfix:match('()'..':'..'.*')")    
+            .appendLine("if queueIdx == nil then")
+            .appendLine("  redis.call('RPUSH', '#wrongfodata', job)")
+            .appendLine("  redis.call('ZREM', foqueue, foworker)")
+            .appendLine("  redis.call('DEL', foworker)")
+            .appendLine("  return 2;")
+            .appendLine("end")
+            .appendLine("local queuename = string.sub(postfix, queueIdx+1, -1)")
+            .appendLine("redis.call('RPUSH', queuename, job)")
+            .appendLine("redis.call('ZREM', foqueue, foworker)")
+            .appendLine("redis.call('DEL', foworker)")
+            .appendLine("return 0")
+            .toString();
+    
     /**
      * Default channel for admin jobs
      */
-    String ADMIN_CHANNEL = "admin";
+    public static final String ADMIN_CHANNEL = "admin";
+    
+    static class StringBuilderWithNewline {
+        private StringBuilder sb;
+
+        public StringBuilderWithNewline() {
+            sb = new StringBuilder();
+        }
+
+        public StringBuilderWithNewline appendLine(String str) {
+            sb.append(str).append(System.lineSeparator());
+            return this;
+        }
+        
+        public StringBuilderWithNewline append(String str) {
+            sb.append(str);
+            return this;
+        }
+
+        public String toString() {
+            return sb.toString();
+        }
+    }
 }

--- a/src/main/java/net/greghaines/jesque/worker/FailoverWorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/FailoverWorkerImpl.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2011 Greg Haines
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.greghaines.jesque.worker;
+
+import static net.greghaines.jesque.utils.ResqueConstants.*;
+import static net.greghaines.jesque.worker.JobExecutor.State.*;
+import static net.greghaines.jesque.worker.WorkerEvent.*;
+
+import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import net.greghaines.jesque.ConfigFO;
+import net.greghaines.jesque.utils.JedisUtils;
+import net.greghaines.jesque.utils.JesqueUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import redis.clients.jedis.exceptions.JedisException;
+
+/**
+ * Extends WorkerImpl for failback.
+ * 
+ * @author Greg Haines
+ * @author Animesh Kumar <smile.animesh@gmail.com>
+ * @author Heebyung <heebyung@gmail.com>
+ */
+public class FailoverWorkerImpl extends WorkerImpl {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(FailoverWorkerImpl.class);
+    
+    public int emptyFailoverQueueSleepTimeMs;
+    
+    /**
+     * Verify that the given queues are all valid.
+     * 
+     * @param queues
+     *            the given queues
+     */
+    protected static void checkQueues(final Iterable<String> queues) {
+        if (queues == null) {
+            throw new IllegalArgumentException("queues must not be null");
+        }
+        for (final String queue : queues) {
+            if (queue == null || "".equals(queue)) {
+                throw new IllegalArgumentException("queues' members must not be null: " + queues);
+            }
+        }
+    }
+
+    /**
+     * Creates a new FailoverWorkerImpl, which creates it's own connection to Redis
+     * using values from the config. The worker will only listen to the supplied
+     * failover-queues.
+     * 
+     * @param config
+     *            used to create a connection to Redis and the package prefix
+     *            for incoming jobs
+     * @param queues
+     *            the list of failover-queues to poll
+     */
+    public FailoverWorkerImpl(final ConfigFO config, final Collection<String> queues) {
+        super(config, queues, 
+                new MapBasedJobFactory(JesqueUtils.map(
+                        JesqueUtils.entry("EmptyAction", EmptyAction.class))));
+        this.emptyFailoverQueueSleepTimeMs = config.getEmptyFailoverQueueSleepTimeSec()*1000;
+    }
+    
+    public FailoverWorkerImpl(final ConfigFO config) {
+        this(config, config.getFailoverQueues());
+    }
+    
+    /**
+     * Starts this worker. Registers the worker in Redis and begins polling the
+     * failover-queues for failback. Stop this worker by calling end() on any thread.
+     */
+    @Override
+    public void run() {
+        if (this.state.compareAndSet(NEW, RUNNING)) {
+            try {
+                renameThread("RUNNING");
+                this.threadRef.set(Thread.currentThread());
+                this.jedis.sadd(key(WORKERS), this.name);
+                this.jedis.set(key(WORKER, this.name, STARTED), new SimpleDateFormat(DATE_FORMAT).format(new Date()));
+                this.listenerDelegate.fireEvent(WORKER_START, this, null, null, null, null, null);
+                poll();
+            } finally {
+                renameThread("STOPPING");
+                this.listenerDelegate.fireEvent(WORKER_STOP, this, null, null, null, null, null);
+                this.jedis.srem(key(WORKERS), this.name);
+                this.jedis.del(key(WORKER, this.name), key(WORKER, this.name, STARTED), key(STAT, FAILED, this.name),
+                        key(STAT, PROCESSED, this.name));
+                this.jedis.quit();
+                this.threadRef.set(null);
+            }
+        } else {
+            if (RUNNING.equals(this.state.get())) {
+                throw new IllegalStateException("This FailoverWorkerImpl is already running");
+            } else {
+                throw new IllegalStateException("This FailoverWorkerImpl is shutdown");
+            }
+        }
+    }
+    
+    /**
+     * Polls the failover-queues for failover-data, and failback them if failoverTimeout exceed.
+     */
+    protected void poll() {
+        int missCount = 0;
+        String curQueue = null;
+        while (RUNNING.equals(this.state.get())) {
+            try {
+                if (threadNameChangingEnabled) {
+                    renameThread("Waiting for " + JesqueUtils.join(",", this.queueNames));
+                }
+                curQueue = this.queueNames.poll(emptyFailoverQueueSleepTimeMs, TimeUnit.MILLISECONDS);
+                if (curQueue != null) {
+                    this.queueNames.add(curQueue); // Rotate the queues
+                    checkPaused(); 
+                    // Might have been waiting in poll()/checkPaused() for a while
+                    if (RUNNING.equals(this.state.get())) {
+                        this.listenerDelegate.fireEvent(WORKER_POLL, this, curQueue, null, null, null, null);
+                        final Long result = failback(curQueue);
+                        
+                        if (result != null) {
+                            missCount = 0;
+                            if (result == 0) { 
+                                success(curQueue);
+                            } else {
+                                failure(curQueue);
+                            }
+                        } else if (++missCount >= this.queueNames.size() && RUNNING.equals(this.state.get())) {
+                            // Keeps worker from busy-spinning on empty queues
+                            missCount = 0;
+                            Thread.sleep(emptyFailoverQueueSleepTimeMs);
+                        }
+                    }
+                }
+            } catch (InterruptedException ie) {
+                if (!isShutdown()) {
+                    recoverFromException(curQueue, ie);
+                }
+            } catch (Exception e) {
+                recoverFromException(curQueue, e);
+            }
+        }
+    }
+
+    /**
+     * Handle an exception that was thrown from inside {@link #poll()}
+     * 
+     * @param curQueue
+     *            the name of the queue that was being processed when the
+     *            exception was thrown
+     * @param e
+     *            the exception that was thrown
+     */
+    protected void recoverFromException(final String curQueue, final Exception e) {
+        final RecoveryStrategy recoveryStrategy = this.exceptionHandlerRef.get().onException(this, e, curQueue);
+        switch (recoveryStrategy) {
+        case RECONNECT:
+            LOG.info("Reconnecting to Redis in response to exception", e);
+            final int reconAttempts = getReconnectAttempts();
+            if (!JedisUtils.reconnect(this.jedis, reconAttempts, RECONNECT_SLEEP_TIME)) {
+                LOG.warn("Terminating in response to exception after " + reconAttempts + " to reconnect", e);
+                end(false);
+            } else {
+                authenticateAndSelectDB();
+                LOG.info("Reconnected to Redis");
+            }
+            break;
+        case TERMINATE:
+            LOG.warn("Terminating in response to exception", e);
+            end(false);
+            break;
+        case PROCEED:
+            this.listenerDelegate.fireEvent(WORKER_ERROR, this, curQueue, null, null, null, e);
+            break;
+        default:
+            LOG.error("Unknown RecoveryStrategy: " + recoveryStrategy
+                    + " while attempting to recover from the following exception; worker proceeding...", e);
+            break;
+        }
+    }
+
+    private void authenticateAndSelectDB() {
+        if (this.config.getPassword() != null) {
+            this.jedis.auth(this.config.getPassword());
+        }
+        this.jedis.select(this.config.getDatabase());
+    }
+
+    /**
+     * Update the status in Redis on success.
+     * 
+     * @param curQueue
+     *            the queue the failover-data came from
+     */    
+    private void success(final String curQueue) {
+        if (threadNameChangingEnabled) {
+            renameThread("Processing " + curQueue + " since " + System.currentTimeMillis());
+        }
+        try {
+            this.jedis.incr(key(STAT, PROCESSED));
+            this.jedis.incr(key(STAT, PROCESSED, this.name));
+        } catch (JedisException je) {
+            LOG.warn("Error updating success stats", je);
+        }
+    }
+    
+    /**
+     * Update the status in Redis on failure.
+     * 
+     * @param curQueue
+     *            the queue the failover-data came from
+     */    
+    private void failure(final String curQueue) {
+        if (threadNameChangingEnabled) {
+            renameThread("Processing " + curQueue + " since " + System.currentTimeMillis());
+        }
+        try {
+            this.jedis.incr(key(STAT, FAILED));
+            this.jedis.incr(key(STAT, FAILED, this.name));
+        } catch (JedisException je) {
+            LOG.warn("Error updating failure stats", je);
+        }
+    }
+
+    /**
+     * Creates a unique name, suitable for use with Resque.
+     * 
+     * @return a unique name for this worker
+     */
+    
+    protected String createName() {
+        final StringBuilder buf = new StringBuilder(128);
+        try {
+            buf.append(InetAddress.getLocalHost().getHostName()).append(COLON)
+                    .append(ManagementFactory.getRuntimeMXBean().getName().split("@")[0]) // PID
+                    .append('-').append(this.workerId).append(COLON).append(FAILOVER_QUEUES);
+            for (final String queueName : this.queueNames) {
+                buf.append(',').append(queueName);
+            }
+        } catch (UnknownHostException uhe) {
+            throw new RuntimeException(uhe);
+        }
+        return buf.toString();
+    }
+
+    /**
+     * Load lua-script to redis.
+     * 
+     */
+    protected void scriptLoad() {
+        keyToScriptSha.put(FAILBACK, this.jedis.scriptLoad(FAILBACK_SCRIPT));
+    }
+    
+    /**
+     * Performing failback using given failoverQueue.
+     * 
+     * @param failoverQueue
+     *            the queue the failover-data came from
+     */
+    protected Long failback(String failoverQueue) {
+        return (Long)this.jedis.evalsha(keyToScriptSha.get(FAILBACK), 2, 
+                failoverQueue, 
+                String.valueOf(System.currentTimeMillis()));     
+    }
+
+    public int getEmptyFailoverQueueSleepTimeMs() {
+        return emptyFailoverQueueSleepTimeMs;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return this.namespace + COLON + WORKER + COLON + this.name;
+    }
+    
+    /**
+     * Empty job for passing null-check of jobFactory in WorkerImpl.
+     * 
+     */
+    public static class EmptyAction implements Runnable {
+        private static final Logger LOG = LoggerFactory.getLogger(EmptyAction.class);
+        private final String s;
+
+        public EmptyAction(String s) {
+            this.s = s;
+        }
+
+        public void run() {
+            LOG.debug("EmptyAction.run() {} ", this.s);
+        }
+    }
+}

--- a/src/main/java/net/greghaines/jesque/worker/FailoverWorkerImplFactory.java
+++ b/src/main/java/net/greghaines/jesque/worker/FailoverWorkerImplFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2011 Greg Haines
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.greghaines.jesque.worker;
+
+import java.util.concurrent.Callable;
+
+import net.greghaines.jesque.ConfigFO;
+
+/**
+ * A simple factory for <code>FailoverWorkerImpl</code>s. Designed to be used with
+ * <code>WorkerPool</code>.
+ * 
+ * @author Greg Haines
+ */
+public class FailoverWorkerImplFactory implements Callable<FailoverWorkerImpl> {
+    
+    private final ConfigFO config;
+
+    /**
+     * Create a new factory. Returned <code>FailoverWorkerImpl</code>s will use the
+     * provided arguments.
+     * 
+     * @param config
+     *            used to create a connection to Redis and the package prefix
+     *            for incoming jobs
+     */
+    public FailoverWorkerImplFactory(final ConfigFO config) {
+        this.config = config;
+    }
+
+    /**
+     * Create a new <code>FailoverWorkerImpl</code> using the arguments provided to this
+     * factory's constructor.
+     */
+    public FailoverWorkerImpl call() {
+        return new FailoverWorkerImpl(this.config);
+    }
+}


### PR DESCRIPTION
Queues are polled with an atomic 'lpopFailover' method to store a job on the
failover data-set(failoverQueue, failoverData). If a worker is terminated immediately while processing a job,
that job will be requeued eventually by FailoverWorker. Otherwise it will be just removed from the failover data-set.

Wheather worker terminated nomally or not(SIGTERM, SIGKILL, machine-failure, etc), failback will be run automatically.

And, Lua-script is used for transaction and reduction of latency.
