### PR TITLE
Empty namespace

### DIFF
--- a/src/main/java/net/greghaines/jesque/Config.java
+++ b/src/main/java/net/greghaines/jesque/Config.java
@@ -64,6 +64,9 @@ public class Config implements Serializable {
         if (timeout < 0) {
             throw new IllegalArgumentException("timeout must not be negative: " + timeout);
         }
+        if (namespace == null) {
+            throw new IllegalArgumentException("namespace must not be null");
+        }
         if (database < 0) {
             throw new IllegalArgumentException("database must not be negative: " + database);
         }

--- a/src/main/java/net/greghaines/jesque/Config.java
+++ b/src/main/java/net/greghaines/jesque/Config.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011 Greg Haines
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,12 +21,12 @@ import net.greghaines.jesque.utils.JesqueUtils;
 
 /**
  * An immutable configuration bean for use with the rest of the project.
- * 
+ *
  * @author Greg Haines
  * @see ConfigBuilder
  */
 public class Config implements Serializable {
-    
+
     private static final long serialVersionUID = -6638770587683679373L;
 
     private final String host;
@@ -38,7 +38,7 @@ public class Config implements Serializable {
 
     /**
      * Using a ConfigBuilder is recommended...
-     * 
+     *
      * @param host
      *            the Reds hostname
      * @param port
@@ -53,7 +53,7 @@ public class Config implements Serializable {
      *            the Redis database to use
      * @see ConfigBuilder
      */
-    public Config(final String host, final int port, final int timeout, final String password, final String namespace, 
+    public Config(final String host, final int port, final int timeout, final String password, final String namespace,
             final int database) {
         if (host == null || "".equals(host)) {
             throw new IllegalArgumentException("host must not be null or empty: " + host);
@@ -63,9 +63,6 @@ public class Config implements Serializable {
         }
         if (timeout < 0) {
             throw new IllegalArgumentException("timeout must not be negative: " + timeout);
-        }
-        if (namespace == null || "".equals(namespace)) {
-            throw new IllegalArgumentException("namespace must not be null or empty: " + namespace);
         }
         if (database < 0) {
             throw new IllegalArgumentException("database must not be negative: " + database);

--- a/src/main/java/net/greghaines/jesque/ConfigBuilder.java
+++ b/src/main/java/net/greghaines/jesque/ConfigBuilder.java
@@ -148,6 +148,9 @@ public class ConfigBuilder implements Serializable {
      * @return this ConfigBuilder
      */
     public ConfigBuilder withNamespace(final String namespace) {
+        if (namespace == null) {
+            throw new IllegalArgumentException("namespace must not be null");
+        }
         this.namespace = namespace;
         return this;
     }

--- a/src/main/java/net/greghaines/jesque/ConfigBuilder.java
+++ b/src/main/java/net/greghaines/jesque/ConfigBuilder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011 Greg Haines
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,12 +19,12 @@ import java.io.Serializable;
 
 /**
  * A fluent-style builder for {@link Config}s.
- * 
+ *
  * @author Greg Haines
  * @see Config
  */
 public class ConfigBuilder implements Serializable {
-    
+
     private static final long serialVersionUID = 730947307298353317L;
 
     /** localhost */
@@ -64,7 +64,7 @@ public class ConfigBuilder implements Serializable {
     /**
      * Create a new ConfigBuilder using an existing Config as the starting
      * point.
-     * 
+     *
      * @param startingPoint
      *            the Config instance to copy the values from
      */
@@ -81,7 +81,7 @@ public class ConfigBuilder implements Serializable {
 
     /**
      * Configs created by this ConfigBuilder will have the given Redis hostname.
-     * 
+     *
      * @param host
      *            the Redis hostname
      * @return this ConfigBuilder
@@ -97,7 +97,7 @@ public class ConfigBuilder implements Serializable {
     /**
      * Configs created by this ConfigBuilder will have the given Redis port
      * number.
-     * 
+     *
      * @param port
      *            the Redis port number
      * @return this ConfigBuilder
@@ -113,7 +113,7 @@ public class ConfigBuilder implements Serializable {
     /**
      * Configs created by this ConfigBuilder will have the given Redis
      * connection timeout.
-     * 
+     *
      * @param timeout
      *            the Redis connection timeout
      * @return this ConfigBuilder
@@ -129,7 +129,7 @@ public class ConfigBuilder implements Serializable {
     /**
      * Configs created by this ConfigBuilder will authenticate with the given
      * Redis password.
-     * 
+     *
      * @param password
      *            the Redis password
      * @return this ConfigBuilder
@@ -142,22 +142,19 @@ public class ConfigBuilder implements Serializable {
     /**
      * Configs created by this ConfigBuilder will have the given Redis namespace
      * to prefix keys with.
-     * 
+     *
      * @param namespace
      *            the Redis namespace to prefix keys with
      * @return this ConfigBuilder
      */
     public ConfigBuilder withNamespace(final String namespace) {
-        if (namespace == null || "".equals(namespace)) {
-            throw new IllegalArgumentException("namespace must not be null or empty: " + namespace);
-        }
         this.namespace = namespace;
         return this;
     }
 
     /**
      * Configs created by this ConfigBuilder will use the given Redis database.
-     * 
+     *
      * @param database
      *            the Redis database to use
      * @return this ConfigBuilder

--- a/src/main/java/net/greghaines/jesque/utils/JesqueUtils.java
+++ b/src/main/java/net/greghaines/jesque/utils/JesqueUtils.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011 Greg Haines
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,7 +37,7 @@ import net.greghaines.jesque.worker.UnpermittedJobException;
 
 /**
  * Miscellaneous utilities.
- * 
+ *
  * @author Greg Haines
  */
 public final class JesqueUtils {
@@ -51,7 +51,7 @@ public final class JesqueUtils {
 
     /**
      * Join the given strings, separated by the given separator.
-     * 
+     *
      * @param sep
      *            the separator
      * @param strs
@@ -64,7 +64,7 @@ public final class JesqueUtils {
 
     /**
      * Join the given strings, separated by the given separator.
-     * 
+     *
      * @param sep
      *            the separator
      * @param strs
@@ -83,7 +83,7 @@ public final class JesqueUtils {
 
     /**
      * Builds a namespaced Redis key with the given arguments.
-     * 
+     *
      * @param namespace
      *            the namespace to use
      * @param parts
@@ -96,7 +96,7 @@ public final class JesqueUtils {
 
     /**
      * Builds a namespaced Redis key with the given arguments.
-     * 
+     *
      * @param namespace
      *            the namespace to use
      * @param parts
@@ -105,7 +105,9 @@ public final class JesqueUtils {
      */
     public static String createKey(final String namespace, final Iterable<String> parts) {
         final List<String> list = new LinkedList<String>();
-        list.add(namespace);
+        if (!"".equals(namespace)) {
+          list.add(namespace);
+        }
         for (final String part : parts) {
             list.add(part);
         }
@@ -115,7 +117,7 @@ public final class JesqueUtils {
     /**
      * Creates a Resque backtrace from a Throwable's stack trace. Includes
      * causes.
-     * 
+     *
      * @param t
      *            the Exception to use
      * @return a list of strings that represent how the exception's stacktrace
@@ -134,7 +136,7 @@ public final class JesqueUtils {
 
     /**
      * Add a cause to the backtrace.
-     * 
+     *
      * @param cause
      *            the cause
      * @param bTrace
@@ -174,7 +176,7 @@ public final class JesqueUtils {
      * only parameter or a Constructor with a String and a Throwable as its
      * parameters.</li>
      * </ul>
-     * 
+     *
      * @param type
      *            the String name of the Throwable type
      * @param message
@@ -200,8 +202,8 @@ public final class JesqueUtils {
      *             if the constructor threw an exception
      * @see JesqueUtils#createBacktrace(Throwable)
      */
-    public static Throwable recreateThrowable(final String type, final String message, final List<String> backtrace) 
-            throws ParseException, ClassNotFoundException, NoSuchConstructorException, 
+    public static Throwable recreateThrowable(final String type, final String message, final List<String> backtrace)
+            throws ParseException, ClassNotFoundException, NoSuchConstructorException,
             AmbiguousConstructorException, ReflectiveOperationException {
         final LinkedList<String> bTrace = new LinkedList<String>(backtrace);
         Throwable cause = null;
@@ -218,8 +220,8 @@ public final class JesqueUtils {
         return instantiateThrowable(type, message, cause, stes);
     }
 
-    protected static Throwable instantiateThrowable(final String type, final String message, final Throwable cause, 
-            final StackTraceElement[] stes) throws ClassNotFoundException, AmbiguousConstructorException, 
+    protected static Throwable instantiateThrowable(final String type, final String message, final Throwable cause,
+            final StackTraceElement[] stes) throws ClassNotFoundException, AmbiguousConstructorException,
             ReflectiveOperationException, NoSuchConstructorException {
         Throwable throwable = null;
         boolean causeInited = false;
@@ -302,7 +304,7 @@ public final class JesqueUtils {
 
     /**
      * A convenient way of creating a map on the fly.
-     * 
+     *
      * @param <K> the key type
      * @param <V> the value type
      * @param entries
@@ -321,7 +323,7 @@ public final class JesqueUtils {
     /**
      * Creates a Map.Entry out of the given key and value. Commonly used in
      * conjunction with map(Entry...)
-     * 
+     *
      * @param <K> the key type
      * @param <V> the value type
      * @param key
@@ -336,7 +338,7 @@ public final class JesqueUtils {
 
     /**
      * Creates a Set out of the given keys
-     * 
+     *
      * @param <K> the key type
      * @param keys
      *            the keys
@@ -346,7 +348,7 @@ public final class JesqueUtils {
     public static <K> Set<K> set(final K... keys) {
         return new LinkedHashSet<K>(Arrays.asList(keys));
     }
-    
+
     /**
      * Test for equality.
      * @param obj1 the first object
@@ -361,7 +363,7 @@ public final class JesqueUtils {
     /**
      * Materializes a job by assuming the {@link Job#getClassName()} is a
      * fully-qualified Java type.
-     * 
+     *
      * @param job
      *            the job to materialize
      * @return the materialized job
@@ -382,7 +384,7 @@ public final class JesqueUtils {
     /**
      * Materializes a job by looking up {@link Job#getClassName()} in the
      * provided map of job types.
-     * 
+     *
      * @param job
      *            the job to materialize
      * @param jobTypes
@@ -394,7 +396,7 @@ public final class JesqueUtils {
      * @throws Exception
      *             if there was an exception creating the object
      */
-    public static Object materializeJob(final Job job, final Map<String, Class<?>> jobTypes) 
+    public static Object materializeJob(final Job job, final Map<String, Class<?>> jobTypes)
             throws UnpermittedJobException, Exception {
         final String className = job.getClassName();
         final Class<?> clazz = jobTypes.get(className);
@@ -407,11 +409,11 @@ public final class JesqueUtils {
         }
         return ReflectionUtils.createObject(clazz, job.getArgs(), job.getVars());
     }
-    
+
     /**
      * This is needed because Throwable doesn't override equals() and object
      * equality is not what we want to test.
-     * 
+     *
      * @param ex1
      *            first Throwable
      * @param ex2

--- a/src/test/java/net/greghaines/jesque/TestConfigBuilder.java
+++ b/src/test/java/net/greghaines/jesque/TestConfigBuilder.java
@@ -55,12 +55,12 @@ public class TestConfigBuilder {
         Assert.assertEquals(ConfigBuilder.DEFAULT_PORT, config.getPort());
         Assert.assertEquals(ConfigBuilder.DEFAULT_TIMEOUT, config.getTimeout());
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void testWithHost_Null() {
         new ConfigBuilder().withHost(null);
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void testWithHost_Empty() {
         new ConfigBuilder().withHost("");
@@ -150,14 +150,18 @@ public class TestConfigBuilder {
         Assert.assertEquals(ConfigBuilder.DEFAULT_PORT, config.getPort());
         Assert.assertEquals(ConfigBuilder.DEFAULT_TIMEOUT, config.getTimeout());
     }
-    
-    @Test(expected = IllegalArgumentException.class)
+
+    @Test
     public void testWithNamespace_Null() {
-        new ConfigBuilder().withNamespace(null);
+        final String myNamespace = null;
+        final Config config = new ConfigBuilder().withNamespace(myNamespace).build();
+        Assert.assertEquals(myNamespace, config.getNamespace());
     }
-    
-    @Test(expected = IllegalArgumentException.class)
+
+    @Test
     public void testWithNamespace_Empty() {
-        new ConfigBuilder().withNamespace("");
+        final String myNamespace = "";
+        final Config config = new ConfigBuilder().withNamespace(myNamespace).build();
+        Assert.assertEquals(myNamespace, config.getNamespace());
     }
 }

--- a/src/test/java/net/greghaines/jesque/TestConfigBuilder.java
+++ b/src/test/java/net/greghaines/jesque/TestConfigBuilder.java
@@ -151,11 +151,9 @@ public class TestConfigBuilder {
         Assert.assertEquals(ConfigBuilder.DEFAULT_TIMEOUT, config.getTimeout());
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testWithNamespace_Null() {
-        final String myNamespace = null;
-        final Config config = new ConfigBuilder().withNamespace(myNamespace).build();
-        Assert.assertEquals(myNamespace, config.getNamespace());
+        new ConfigBuilder().withNamespace(null);
     }
 
     @Test

--- a/src/test/java/net/greghaines/jesque/utils/TestJesqueUtils.java
+++ b/src/test/java/net/greghaines/jesque/utils/TestJesqueUtils.java
@@ -30,7 +30,7 @@ public class TestJesqueUtils {
 
     @Test
     public void testCreateKey_VarArgs() {
-        Assert.assertEquals("foo:bar:baz", JesqueUtils.createKey("foo", "bar", "baz"));
+        Assert.assertEquals("bar:baz", JesqueUtils.createKey("", "bar", "baz"));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class TestJesqueUtils {
         Assert.assertEquals("quz", map.get("foo"));
         Assert.assertEquals("quz", map.get("baz"));
     }
-    
+
     @Test
     public void testMaterializeJob() throws Exception {
         final Object action = JesqueUtils.materializeJob(new Job(TestRunnableJob.class.getName()));
@@ -75,12 +75,12 @@ public class TestJesqueUtils {
         Assert.assertNotNull(action2);
         Assert.assertEquals(TestCallableJob.class, action2.getClass());
     }
-    
+
     @Test(expected = ClassCastException.class)
     public void testMaterializeJob_NotRunnable() throws Exception {
         JesqueUtils.materializeJob(new Job(TestBadJob.class.getName()));
     }
-    
+
     @Test
     public void testMaterializeJob_Types() throws Exception {
         final Map<String, Class<?>> jobTypes = new HashMap<String, Class<?>>();
@@ -93,57 +93,57 @@ public class TestJesqueUtils {
         Assert.assertNotNull(action2);
         Assert.assertEquals(TestCallableJob.class, action2.getClass());
     }
-    
+
     @Test(expected = UnpermittedJobException.class)
     public void testMaterializeJob_Types_NotPermitted() throws Exception {
         final Map<String, Class<?>> jobTypes = new HashMap<String, Class<?>>();
         JesqueUtils.materializeJob(new Job("TestRunnableJob"), jobTypes);
     }
-    
+
     @Test(expected = ClassCastException.class)
     public void testMaterializeJob_Types_NotRunnable() throws Exception {
         final Map<String, Class<?>> jobTypes = new HashMap<String, Class<?>>();
         jobTypes.put("TestBadJob", TestBadJob.class);
         JesqueUtils.materializeJob(new Job("TestBadJob"), jobTypes);
     }
-    
+
     @Test
     public void testRecreateStackTrace() throws ParseException {
-        final List<String> bTrace = new ArrayList<String>(Arrays.asList("foo", 
-                "\tat net.greghaines.jesque.Job.<init>(Job.java:30)", 
-                "\tat net.greghaines.jesque.Job.<init>(Job.java)", 
-                "\tat net.greghaines.jesque.Job.<init>(Unknown Source)", 
+        final List<String> bTrace = new ArrayList<String>(Arrays.asList("foo",
+                "\tat net.greghaines.jesque.Job.<init>(Job.java:30)",
+                "\tat net.greghaines.jesque.Job.<init>(Job.java)",
+                "\tat net.greghaines.jesque.Job.<init>(Unknown Source)",
                 "\tat net.greghaines.jesque.Job.<init>(Native Method)"));
         final StackTraceElement[] stes = JesqueUtils.recreateStackTrace(bTrace);
         Assert.assertEquals(4, stes.length);
     }
-    
+
     @Test(expected = ParseException.class)
     public void testRecreateStackTrace_BadFormat() throws ParseException {
         final List<String> bTrace = new ArrayList<String>(Arrays.asList("\tat net.greghaines"));
         final StackTraceElement[] stes = JesqueUtils.recreateStackTrace(bTrace);
         Assert.assertEquals(0, stes.length);
     }
-    
+
     @Test
     public void testRecreateStackTrace_NotFormat() throws ParseException {
         final List<String> bTrace = Arrays.asList("foo", "bar");
         final StackTraceElement[] stes = JesqueUtils.recreateStackTrace(bTrace);
         Assert.assertEquals(0, stes.length);
     }
-    
+
     @Test
     public void testRecreateStackTrace_Empty() throws ParseException {
         final StackTraceElement[] stes = JesqueUtils.recreateStackTrace(new ArrayList<String>());
         Assert.assertEquals(0, stes.length);
     }
-    
+
     @Test
     public void testRecreateStackTrace_Null() throws ParseException {
         final StackTraceElement[] stes = JesqueUtils.recreateStackTrace(null);
         Assert.assertEquals(0, stes.length);
     }
-    
+
     @Test
     public void testEqual() {
         Throwable ex1 = new RuntimeException();
@@ -165,7 +165,7 @@ public class TestJesqueUtils {
         ex2 = new RuntimeException("foo", new Exception());
         Assert.assertTrue(JesqueUtils.equal(ex1, ex2));
     }
-    
+
     @Test
     public void testNullSafeEquals() {
         final String str1 = "foo";
@@ -178,14 +178,14 @@ public class TestJesqueUtils {
         Assert.assertTrue(JesqueUtils.nullSafeEquals(str1, str2));
         Assert.assertFalse(JesqueUtils.nullSafeEquals(str1, str3));
     }
-    
+
     public static class TestRunnableJob implements Runnable {
         @Override
         public void run() {
             // Do nothing
         }
     }
-    
+
     public static class TestCallableJob implements Callable<Object> {
         @Override
         public Object call() {
@@ -193,7 +193,7 @@ public class TestJesqueUtils {
             return null;
         }
     }
-    
+
     public static class TestBadJob {
         public void run() {
             // Do nothing


### PR DESCRIPTION
In the current implementation a `namespace` is required. By default it's set to `resque` but it cannot be set to an empty string or nil.

Sidekiq by default uses no namespace so to get this to work with Sidekiq you have to set a `namespace` so that the namespaces from jesque and Sidekiq match up. See also http://stackoverflow.com/questions/21974356/how-to-enqueue-a-job-in-sidekiq-with-java-or-scala

It would be nice if you could specify nil or empty namespace in jesque so it will would with Resque and Sidekiq out of the box.
