### PR TITLE
Apply Jedis 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     </prerequisites>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jedis.version>2.6.2</jedis.version>
+        <jedis.version>2.7.0</jedis.version>
         <jackson.version>2.5.1</jackson.version>
         <slf4j.version>1.7.10</slf4j.version>
         <logback.version>1.1.2</logback.version>


### PR DESCRIPTION
AFAIK Jesque heavily relied on BinaryJedis.quit().

Recently we found an issue on BinaryJedis.quit(), and it was fixed. 
Please refer https://github.com/xetorthio/jedis/commit/aa9a5e25996df0c425fcb07ba94f33f9457e832d

It's published only 2.7.0, so I recommend jesque to upgrade Jedis to 2.7.0.

Thanks!