### PR TITLE
add recurring feature that allows running a job every N seconds

### DIFF
--- a/src/main/java/net/greghaines/jesque/client/Client.java
+++ b/src/main/java/net/greghaines/jesque/client/Client.java
@@ -94,4 +94,32 @@ public interface Client {
      *             if the queue is null or empty, if the job is null
      */
     void removeDelayedEnqueue(String queue, Job job);
+
+    /**
+     * Queues a job to be in the future and recur
+     *
+     * @param queue
+     *          the queue to add the Job too
+     * @param job
+     *          the job to be enqueued
+     * @param future
+     *          timestamp when the job will run
+     * @param frequency
+     *          frequency in millis how often the job will run
+     * @throws IllegalArgumentException
+     *          if the queue is null or empty, if the job is null
+     */
+    void recurringEnqueue(String queue, Job job, long future, long frequency);
+
+    /**
+     * Removes a queued recurring job.
+     *
+     * @param queue
+     *            the queue to remove the Job from
+     * @param job
+     *            the job to be removed
+     * @throws IllegalArgumentException
+     *             if the queue is null or empty, if the job is null
+     */
+    void removeRecurringEnqueue(String queue, Job job);
 }

--- a/src/main/java/net/greghaines/jesque/client/ClientImpl.java
+++ b/src/main/java/net/greghaines/jesque/client/ClientImpl.java
@@ -157,6 +157,24 @@ public class ClientImpl extends AbstractClient {
         doRemoveDelayedEnqueue(this.jedis, getNamespace(), queue, msg);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doRecurringEnqueue(final String queue, final String msg, final long future, final long frequency) throws Exception{
+        ensureJedisConnection();
+        doRecurringEnqueue(this.jedis, getNamespace(), queue, msg, future, frequency);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doRemoveRecurringEnqueue(final String queue, final String msg) throws Exception{
+        ensureJedisConnection();
+        doRemoveRecurringEnqueue(this.jedis, getNamespace(), queue, msg);
+    }
+
     private void authenticateAndSelectDB() {
         if (this.config.getPassword() != null) {
             this.jedis.auth(this.config.getPassword());

--- a/src/main/java/net/greghaines/jesque/client/ClientPoolImpl.java
+++ b/src/main/java/net/greghaines/jesque/client/ClientPoolImpl.java
@@ -125,6 +125,7 @@ public class ClientPoolImpl extends AbstractClient {
     /**
      * {@inheritDoc}
      */
+    @Override
     protected void doRemoveDelayedEnqueue(final String queue, final String msg) throws Exception {
         PoolUtils.doWorkInPool(this.jedisPool, new PoolWork<Jedis, Void>() {
             /**
@@ -133,6 +134,34 @@ public class ClientPoolImpl extends AbstractClient {
             @Override
             public Void doWork(final Jedis jedis) {
                 doRemoveDelayedEnqueue(jedis, getNamespace(), queue, msg);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    protected void doRecurringEnqueue(final String queue, final String msg, final long future, final long frequency) throws Exception {
+        PoolUtils.doWorkInPool(this.jedisPool, new PoolWork<Jedis, Void>() {
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public Void doWork(final Jedis jedis) {
+                doRecurringEnqueue(jedis, getNamespace(), queue, msg, future, frequency);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    protected void doRemoveRecurringEnqueue(final String queue, final String msg) throws Exception {
+        PoolUtils.doWorkInPool(this.jedisPool, new PoolWork<Jedis, Void>() {
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public Void doWork(final Jedis jedis) {
+                doRemoveRecurringEnqueue(jedis, getNamespace(), queue, msg);
                 return null;
             }
         });

--- a/src/main/java/net/greghaines/jesque/utils/JedisUtils.java
+++ b/src/main/java/net/greghaines/jesque/utils/JedisUtils.java
@@ -34,6 +34,7 @@ public final class JedisUtils {
     private static final Logger LOG = LoggerFactory.getLogger(JedisUtils.class);
     private static final String LIST = "list";
     private static final String ZSET = "zset";
+    private static final String HASH = "hash";
     private static final String NONE = "none";
 
     /**
@@ -133,6 +134,11 @@ public final class JedisUtils {
         return ZSET.equalsIgnoreCase(jedis.type(key));
     }
 
+    public static boolean isRecurringQueue(final Jedis jedis, final String queueKey, final String hashKey) {
+        final String hashType = jedis.type(hashKey);
+        return (isDelayedQueue(jedis, queueKey) && HASH.equalsIgnoreCase(hashType));
+    }
+
     /**
      * Determines if the queue identified by the given key is used.
      * 
@@ -158,6 +164,12 @@ public final class JedisUtils {
     public static boolean canUseAsDelayedQueue(final Jedis jedis, final String key) {
         final String type = jedis.type(key);
         return (ZSET.equalsIgnoreCase(type) || NONE.equalsIgnoreCase(type));
+    }
+
+    public static boolean canUseAsRecurringQueue(final Jedis jedis, final String queueKey, final String hashKey)
+    {
+        final String hashType = jedis.type(hashKey);
+        return (canUseAsDelayedQueue(jedis, queueKey) && (HASH.equalsIgnoreCase(hashType) || NONE.equalsIgnoreCase(hashType)));
     }
 
     private JedisUtils() {

--- a/src/main/java/net/greghaines/jesque/utils/JesqueUtils.java
+++ b/src/main/java/net/greghaines/jesque/utils/JesqueUtils.java
@@ -16,6 +16,7 @@
 package net.greghaines.jesque.utils;
 
 import static net.greghaines.jesque.utils.ResqueConstants.COLON;
+import static net.greghaines.jesque.utils.ResqueConstants.FREQUENCY;
 
 import java.lang.reflect.InvocationTargetException;
 import java.text.ParseException;
@@ -92,6 +93,10 @@ public final class JesqueUtils {
      */
     public static String createKey(final String namespace, final String... parts) {
         return createKey(namespace, Arrays.asList(parts));
+    }
+
+    public static String createRecurringHashKey(final String queue) {
+        return createKey(queue, FREQUENCY);
     }
 
     /**

--- a/src/main/java/net/greghaines/jesque/utils/ResqueConstants.java
+++ b/src/main/java/net/greghaines/jesque/utils/ResqueConstants.java
@@ -60,6 +60,7 @@ public interface ResqueConstants {
     String WORKERS = "workers";
     String CHANNEL = "channel";
     String INFLIGHT = "inflight";
+    String FREQUENCY = "frequency";
 
     /**
      * Default channel for admin jobs

--- a/src/test/java/net/greghaines/jesque/RecurringQueueTest.java
+++ b/src/test/java/net/greghaines/jesque/RecurringQueueTest.java
@@ -81,7 +81,12 @@ public class RecurringQueueTest {
         // Assert that the job was run by the worker
         jedis = createJedis(config);
         try {
-            Assert.assertEquals(String.valueOf(times), jedis.get(createKey(config.getNamespace(), STAT, PROCESSED)));
+            Long processedTimes = Long.valueOf(jedis.get(createKey(config.getNamespace(), STAT, PROCESSED)));
+
+            // allowing for off by one error
+            Long oneOrZero = Math.abs(times - processedTimes);
+
+            Assert.assertTrue(oneOrZero == 0 || oneOrZero == 1);
             Assert.assertNull(jedis.get(createKey(config.getNamespace(), STAT, FAILED)));
             Assert.assertEquals(Long.valueOf(0),
                     jedis.zcount(createKey(config.getNamespace(), QUEUE, recurringTestQueue), "-inf", "+inf"));

--- a/src/test/java/net/greghaines/jesque/RecurringQueueTest.java
+++ b/src/test/java/net/greghaines/jesque/RecurringQueueTest.java
@@ -1,0 +1,98 @@
+package net.greghaines.jesque;
+
+import net.greghaines.jesque.client.Client;
+import net.greghaines.jesque.client.ClientImpl;
+import net.greghaines.jesque.utils.JesqueUtils;
+import net.greghaines.jesque.worker.MapBasedJobFactory;
+import net.greghaines.jesque.worker.Worker;
+import net.greghaines.jesque.worker.WorkerImpl;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import static net.greghaines.jesque.TestUtils.createJedis;
+import static net.greghaines.jesque.utils.JesqueUtils.createKey;
+import static net.greghaines.jesque.utils.JesqueUtils.entry;
+import static net.greghaines.jesque.utils.JesqueUtils.map;
+import static net.greghaines.jesque.utils.ResqueConstants.*;
+import static net.greghaines.jesque.utils.ResqueConstants.QUEUE;
+
+/**
+ * Created by Karthik (@argvk) on 6/3/15.
+ */
+public class RecurringQueueTest {
+
+    private static final Config config = new ConfigBuilder().build();
+    private static final String recurringTestQueue = "fooRecurring";
+    private static final long recurringFrequency = 1000;
+    private static final Client client = new ClientImpl(config);
+    private static final String queueKey = createKey(config.getNamespace(), QUEUE, recurringTestQueue);
+    private static final String hashKey = JesqueUtils.createRecurringHashKey(queueKey);
+
+    @Before
+    public void resetRedis() {
+        TestUtils.resetRedis(config);
+    }
+
+    @Test
+    public void testCode() throws Exception {
+
+        Job job = new Job("TestAction", new Object[]{1, 2.3, true, "test", Arrays.asList("inner", 4.5)});
+        client.recurringEnqueue(recurringTestQueue, job, System.currentTimeMillis() + recurringFrequency, recurringFrequency);
+
+        Jedis jedis = createJedis(config);
+        try { // Assert that we enqueued the job
+            Assert.assertEquals(Long.valueOf(1),
+                    jedis.zcount(queueKey, "-inf", "+inf"));
+            Set<String> jobSet = jedis.zrangeByScore(queueKey, "-inf", "+inf", 0, 1);
+
+            String jobString = jobSet.iterator().next();
+            Assert.assertEquals(String.valueOf(recurringFrequency),
+                    jedis.hget(hashKey, jobString));
+        } finally {
+            jedis.quit();
+        }
+
+        // Create and mark the start worker
+        final Worker worker = new WorkerImpl(config, Arrays.asList(recurringTestQueue),
+                new MapBasedJobFactory(map(entry("TestAction", TestAction.class))));
+        final Thread workerThread = new Thread(worker);
+        Long startMillis = System.currentTimeMillis();
+        workerThread.start();
+
+        try { // let the worker run for some time,
+            Thread.sleep(1000 * 6);
+        } finally { // Stop the worker
+            TestUtils.stopWorker(worker, workerThread);
+        }
+
+        // stop the recurring queue and mark it as ended
+        client.removeRecurringEnqueue(recurringTestQueue, job);
+        Long endMillis = System.currentTimeMillis();
+
+        // should have run (startMillis-endMillis/frequency)
+        Long times = ((endMillis - startMillis)/recurringFrequency);
+
+        // Assert that the job was run by the worker
+        jedis = createJedis(config);
+        try {
+            Assert.assertEquals(String.valueOf(times), jedis.get(createKey(config.getNamespace(), STAT, PROCESSED)));
+            Assert.assertNull(jedis.get(createKey(config.getNamespace(), STAT, FAILED)));
+            Assert.assertEquals(Long.valueOf(0),
+                    jedis.zcount(createKey(config.getNamespace(), QUEUE, recurringTestQueue), "-inf", "+inf"));
+            Assert.assertEquals(Long.valueOf(0), jedis.hlen(hashKey));
+        } finally {
+            jedis.quit();
+        }
+    }
+
+    @After
+    public void closeClient() {
+        client.end();
+    }
+}

--- a/src/test/java/net/greghaines/jesque/RemoveDelayedQueueTest.java
+++ b/src/test/java/net/greghaines/jesque/RemoveDelayedQueueTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import redis.clients.jedis.Jedis;
 /**
- * Created by vk on 4/2/15.
+ * Created by Karthik (@argvk) on 4/2/15.
  */
 public class RemoveDelayedQueueTest {
 


### PR DESCRIPTION
* a recurring job has a schedule in zset with the next timestamp as the
score
* the frequency of the job is stored in a hash
* on pop the frequency and the score are summed up to form the new score
and added back to the zset
* a delete recurring removes it from the zset and hash
* add delete and pop operations run on a redis transaction

related issue #77 