### PR TITLE
Support JMX monitoring for worker pool status

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/WorkerPoolMXBean.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerPoolMXBean.java
@@ -1,0 +1,18 @@
+package net.greghaines.jesque.worker;
+
+public interface WorkerPoolMXBean {
+    /**
+     * @return number of total workers
+     */
+    int getTotalWorkers();
+
+    /**
+     * @return number of active (processing) workers
+     */
+    int getActiveWorkers();
+
+    /**
+     * @return number of idle workers
+     */
+    int getIdleWorkers();
+}


### PR DESCRIPTION
Hello,
I implemented a feature to support JMX monitoring about following worker pool status;

- Number of total workers
- Number of active (processing) workers
- Number of idle workers

How about this?