### PR TITLE
MultiplePriorityQueues: Add ability to POP first message from a list of queues

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/Worker.java
+++ b/src/main/java/net/greghaines/jesque/worker/Worker.java
@@ -99,7 +99,7 @@ public interface Worker extends JobExecutor, Runnable {
      * Clear any current queues and poll the given queues <b>in the specified order</b>.
      * @param queues the queues to poll
      */
-    void setQueues(List<String> queues);
+    void setOrderedPriorityQueues(List<String> queues);
     
     /**
      * @return the worker event emitter for this worker

--- a/src/main/java/net/greghaines/jesque/worker/Worker.java
+++ b/src/main/java/net/greghaines/jesque/worker/Worker.java
@@ -18,6 +18,7 @@ package net.greghaines.jesque.worker;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * A Worker polls for Jobs from a specified list of queues, executing them in
@@ -93,6 +94,12 @@ public interface Worker extends JobExecutor, Runnable {
      * @param queues the queues to poll
      */
     void setQueues(Collection<String> queues);
+
+    /**
+     * Clear any current queues and poll the given queues <b>in the specified order</b>.
+     * @param queues the queues to poll
+     */
+    void setQueues(List<String> queues);
     
     /**
      * @return the worker event emitter for this worker

--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -15,18 +15,22 @@
  */
 package net.greghaines.jesque.worker;
 
+
 import static net.greghaines.jesque.utils.ResqueConstants.*;
 import static net.greghaines.jesque.worker.JobExecutor.State.*;
 import static net.greghaines.jesque.worker.WorkerEvent.*;
 import static net.greghaines.jesque.worker.WorkerImpl.NextQueueStrategy.RESET_TO_HIGHEST_PRIORITY;
 
 import java.io.IOException;
-import java.lang.Throwable;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.Callable;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -66,6 +70,7 @@ public class WorkerImpl implements Worker {
     protected static final int RECONNECT_ATTEMPTS = 120; // Total time: 10 min
     private static final String LPOPLPUSH_LUA = "/workerScripts/jesque_lpoplpush.lua";
     private static final String POP_LUA = "/workerScripts/jesque_pop.lua";
+    private static final String POP_FROM_MULTIPLE_PRIO_QUEUES = "/workerScripts/fromMultiplePriorityQueues.lua";
 
     // Set the thread name to the message for debugging
     private static volatile boolean threadNameChangingEnabled = false;
@@ -210,7 +215,7 @@ public class WorkerImpl implements Worker {
                 this.listenerDelegate.fireEvent(WORKER_START, this, null, null, null, null, null);
                 this.popScriptHash.set(this.jedis.scriptLoad(ScriptUtils.readScript(POP_LUA)));
                 this.lpoplpushScriptHash.set(this.jedis.scriptLoad(ScriptUtils.readScript(LPOPLPUSH_LUA)));
-                this.multiPriorityQueuesScriptHash.set(this.jedis.scriptLoad(ScriptUtils.readScript(LPOPLPUSH_LUA)));
+                this.multiPriorityQueuesScriptHash.set(this.jedis.scriptLoad(ScriptUtils.readScript(POP_FROM_MULTIPLE_PRIO_QUEUES)));
                 poll();
             } catch (Exception ex) {
                 LOG.error("Uncaught exception in worker run-loop!", ex);

--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -15,27 +15,8 @@
  */
 package net.greghaines.jesque.worker;
 
-import static net.greghaines.jesque.utils.ResqueConstants.*;
-import static net.greghaines.jesque.worker.JobExecutor.State.*;
-import static net.greghaines.jesque.worker.WorkerEvent.*;
-
-import java.io.IOException;
-import java.lang.Throwable;
-import java.lang.management.ManagementFactory;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.text.SimpleDateFormat;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.Callable;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import net.greghaines.jesque.Config;
 import net.greghaines.jesque.Job;
 import net.greghaines.jesque.JobFailure;
@@ -45,15 +26,55 @@ import net.greghaines.jesque.utils.JedisUtils;
 import net.greghaines.jesque.utils.JesqueUtils;
 import net.greghaines.jesque.utils.ScriptUtils;
 import net.greghaines.jesque.utils.VersionUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisException;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.Callable;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static net.greghaines.jesque.utils.ResqueConstants.COLON;
+import static net.greghaines.jesque.utils.ResqueConstants.DATE_FORMAT;
+import static net.greghaines.jesque.utils.ResqueConstants.FAILED;
+import static net.greghaines.jesque.utils.ResqueConstants.INFLIGHT;
+import static net.greghaines.jesque.utils.ResqueConstants.JAVA_DYNAMIC_QUEUES;
+import static net.greghaines.jesque.utils.ResqueConstants.PROCESSED;
+import static net.greghaines.jesque.utils.ResqueConstants.QUEUE;
+import static net.greghaines.jesque.utils.ResqueConstants.QUEUES;
+import static net.greghaines.jesque.utils.ResqueConstants.STARTED;
+import static net.greghaines.jesque.utils.ResqueConstants.STAT;
+import static net.greghaines.jesque.utils.ResqueConstants.WORKER;
+import static net.greghaines.jesque.utils.ResqueConstants.WORKERS;
+import static net.greghaines.jesque.worker.JobExecutor.State.NEW;
+import static net.greghaines.jesque.worker.JobExecutor.State.RUNNING;
+import static net.greghaines.jesque.worker.JobExecutor.State.SHUTDOWN;
+import static net.greghaines.jesque.worker.JobExecutor.State.SHUTDOWN_IMMEDIATE;
+import static net.greghaines.jesque.worker.WorkerEvent.JOB_EXECUTE;
+import static net.greghaines.jesque.worker.WorkerEvent.JOB_FAILURE;
+import static net.greghaines.jesque.worker.WorkerEvent.JOB_PROCESS;
+import static net.greghaines.jesque.worker.WorkerEvent.JOB_SUCCESS;
+import static net.greghaines.jesque.worker.WorkerEvent.WORKER_ERROR;
+import static net.greghaines.jesque.worker.WorkerEvent.WORKER_POLL;
+import static net.greghaines.jesque.worker.WorkerEvent.WORKER_START;
+import static net.greghaines.jesque.worker.WorkerEvent.WORKER_STOP;
+import static net.greghaines.jesque.worker.WorkerImpl.NextQueueStrategy.DRAIN_WHILE_MESSAGES_EXISTS;
+import static net.greghaines.jesque.worker.WorkerImpl.NextQueueStrategy.RESET_TO_HIGHEST_PRIORITY;
 
 /**
  * WorkerImpl is an implementation of the Worker interface. Obeys the contract of a Resque worker in Redis.
@@ -65,9 +86,12 @@ public class WorkerImpl implements Worker {
     protected static final long EMPTY_QUEUE_SLEEP_TIME = 500; // 500 ms
     protected static final long RECONNECT_SLEEP_TIME = 5000; // 5 sec
     protected static final int RECONNECT_ATTEMPTS = 120; // Total time: 10 min
-    
+    private static final String LPOPLPUSH_LUA = "/workerScripts/jesque_lpoplpush.lua";
+    private static final String POP_LUA = "/workerScripts/jesque_pop.lua";
+
     // Set the thread name to the message for debugging
     private static volatile boolean threadNameChangingEnabled = false;
+    private final NextQueueStrategy nextQueueStrategy;
 
     /**
      * @return true if worker threads names will change during normal operation
@@ -113,6 +137,7 @@ public class WorkerImpl implements Worker {
     private final AtomicBoolean processingJob = new AtomicBoolean(false);
     private final AtomicReference<String> popScriptHash = new AtomicReference<>(null);
     private final AtomicReference<String> lpoplpushScriptHash = new AtomicReference<>(null);
+    private final AtomicReference<String> multiPriorityQueuesScriptHash = new AtomicReference<>(null);
     private final long workerId = WORKER_COUNTER.getAndIncrement();
     private final String threadNameBase = "Worker-" + this.workerId + " Jesque-" + VersionUtils.getVersion() + ": ";
     private final AtomicReference<Thread> threadRef = new AtomicReference<Thread>(null);
@@ -144,6 +169,25 @@ public class WorkerImpl implements Worker {
      */
     public WorkerImpl(final Config config, final Collection<String> queues, final JobFactory jobFactory, 
             final Jedis jedis) {
+        this(config,
+                (queues == null ? Collections.EMPTY_LIST : new ArrayList<>(queues)),
+                jobFactory,
+                jedis,
+                DRAIN_WHILE_MESSAGES_EXISTS);
+    }
+
+    /**
+     * Creates a new WorkerImpl, with the given connection to Redis.<br>
+     * The worker will only listen to the supplied queues and execute jobs that are provided by the given job factory.
+     * @param config used to create a connection to Redis and the package prefix for incoming jobs
+     * @param queues the list of queues to poll
+     * @param jobFactory the job factory that materializes the jobs
+     * @param jedis the connection to Redis
+     * @param nextQueueStrategy defines worker behaviour once it has found messages in a queue
+     * @throws IllegalArgumentException if either config, queues, jobFactory or jedis is null
+     */
+    public WorkerImpl(final Config config, final List<String> queues, final JobFactory jobFactory,
+            final Jedis jedis, NextQueueStrategy nextQueueStrategy) {
         if (config == null) {
             throw new IllegalArgumentException("config must not be null");
         }
@@ -154,6 +198,7 @@ public class WorkerImpl implements Worker {
             throw new IllegalArgumentException("jedis must not be null");
         }
         checkQueues(queues);
+        this.nextQueueStrategy = nextQueueStrategy;
         this.config = config;
         this.jobFactory = jobFactory;
         this.namespace = config.getNamespace();
@@ -185,9 +230,9 @@ public class WorkerImpl implements Worker {
                 this.jedis.sadd(key(WORKERS), this.name);
                 this.jedis.set(key(WORKER, this.name, STARTED), new SimpleDateFormat(DATE_FORMAT).format(new Date()));
                 this.listenerDelegate.fireEvent(WORKER_START, this, null, null, null, null, null);
-                this.popScriptHash.set(this.jedis.scriptLoad(ScriptUtils.readScript("/workerScripts/jesque_pop.lua")));
-                this.lpoplpushScriptHash.set(this.jedis.scriptLoad(
-                        ScriptUtils.readScript("/workerScripts/jesque_lpoplpush.lua")));
+                this.popScriptHash.set(this.jedis.scriptLoad(ScriptUtils.readScript(POP_LUA)));
+                this.lpoplpushScriptHash.set(this.jedis.scriptLoad(ScriptUtils.readScript(LPOPLPUSH_LUA)));
+                this.multiPriorityQueuesScriptHash.set(this.jedis.scriptLoad(ScriptUtils.readScript(LPOPLPUSH_LUA)));
                 poll();
             } catch (Exception ex) {
                 LOG.error("Uncaught exception in worker run-loop!", ex);
@@ -328,6 +373,14 @@ public class WorkerImpl implements Worker {
      */
     @Override
     public void setQueues(final Collection<String> queues) {
+        setQueues(new ArrayList<>(queues));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setQueues(final List<String> queues) {
         checkQueues(queues);
         this.queueNames.clear();
         this.queueNames.addAll((queues == ALL_QUEUES) // Using object equality on purpose
@@ -408,9 +461,8 @@ public class WorkerImpl implements Worker {
                 if (threadNameChangingEnabled) {
                     renameThread("Waiting for " + JesqueUtils.join(",", this.queueNames));
                 }
-                curQueue = this.queueNames.poll(EMPTY_QUEUE_SLEEP_TIME, TimeUnit.MILLISECONDS);
+                curQueue = getNextQueue();
                 if (curQueue != null) {
-                    this.queueNames.add(curQueue); // Rotate the queues
                     checkPaused(); 
                     // Might have been waiting in poll()/checkPaused() for a while
                     if (RUNNING.equals(this.state.get())) {
@@ -419,10 +471,13 @@ public class WorkerImpl implements Worker {
                         if (payload != null) {
                             process(ObjectMapperFactory.get().readValue(payload, Job.class), curQueue);
                             missCount = 0;
-                        } else if (++missCount >= this.queueNames.size() && RUNNING.equals(this.state.get())) {
-                            // Keeps worker from busy-spinning on empty queues
-                            missCount = 0;
-                            Thread.sleep(EMPTY_QUEUE_SLEEP_TIME);
+                        } else {
+                            missCount++;
+                            if (shouldSleep(missCount) && RUNNING.equals(this.state.get())) {
+                                // Keeps worker from busy-spinning on empty queues
+                                missCount = 0;
+                                Thread.sleep(EMPTY_QUEUE_SLEEP_TIME);
+                            }
                         }
                     }
                 }
@@ -440,6 +495,27 @@ public class WorkerImpl implements Worker {
         }
     }
 
+    private boolean shouldSleep(int missCount) {
+        return nextQueueStrategy == RESET_TO_HIGHEST_PRIORITY ||
+                missCount >= this.queueNames.size();
+    }
+
+    protected String getNextQueue() throws InterruptedException {
+        switch (nextQueueStrategy) {
+            case DRAIN_WHILE_MESSAGES_EXISTS:
+                final String nextPollQueue = this.queueNames.poll(EMPTY_QUEUE_SLEEP_TIME, TimeUnit.MILLISECONDS);
+                if (nextPollQueue != null) {
+                    // Rotate the queues
+                    this.queueNames.add(nextPollQueue);
+                }
+                return nextPollQueue;
+            case RESET_TO_HIGHEST_PRIORITY:
+                return JesqueUtils.join(",", this.queueNames);
+            default:
+                throw new RuntimeException("Unimplemented 'nextQueueStrategy'");
+        }
+    }
+
     /**
      * Remove a job from the given queue.
      * @param curQueue the queue to remove a job from
@@ -447,8 +523,15 @@ public class WorkerImpl implements Worker {
      */
     protected String pop(final String curQueue) {
         final String key = key(QUEUE, curQueue);
-        return (String) this.jedis.evalsha(this.popScriptHash.get(), 3, key, key(INFLIGHT, this.name, curQueue), 
-                JesqueUtils.createRecurringHashKey(key), Long.toString(System.currentTimeMillis()));
+        switch (nextQueueStrategy) {
+            case DRAIN_WHILE_MESSAGES_EXISTS:
+                return (String) this.jedis.evalsha(this.popScriptHash.get(), 3, key, key(INFLIGHT, this.name, curQueue),
+                        JesqueUtils.createRecurringHashKey(key), Long.toString(System.currentTimeMillis()));
+            case RESET_TO_HIGHEST_PRIORITY:
+                return (String) this.jedis.evalsha(this.multiPriorityQueuesScriptHash.get(), 1, curQueue);
+            default:
+                throw new RuntimeException("Unimplemented 'nextQueueStrategy'");
+        }
     }
 
     /**
@@ -707,5 +790,17 @@ public class WorkerImpl implements Worker {
     @Override
     public String toString() {
         return this.namespace + COLON + WORKER + COLON + this.name;
+    }
+
+    public enum NextQueueStrategy {
+        /**
+         * Would drain messages as long as current queue is not empty
+         */
+        DRAIN_WHILE_MESSAGES_EXISTS,
+
+        /**
+         * Would reset to check {first queue, second queue, etc'} after each message
+         */
+        RESET_TO_HIGHEST_PRIORITY
     }
 }

--- a/src/main/java/net/greghaines/jesque/worker/WorkerPool.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerPool.java
@@ -253,6 +253,14 @@ public class WorkerPool implements Worker {
      */
     @Override
     public void setQueues(final Collection<String> queues) {
+        setQueues(new ArrayList<>(queues));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setQueues(final List<String> queues) {
         for (final Worker worker : this.workers) {
             worker.setQueues(queues);
         }

--- a/src/main/java/net/greghaines/jesque/worker/WorkerPool.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerPool.java
@@ -253,16 +253,16 @@ public class WorkerPool implements Worker {
      */
     @Override
     public void setQueues(final Collection<String> queues) {
-        setQueues(new ArrayList<>(queues));
+        setOrderedPriorityQueues(new ArrayList<>(queues));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void setQueues(final List<String> queues) {
+    public void setOrderedPriorityQueues(final List<String> queues) {
         for (final Worker worker : this.workers) {
-            worker.setQueues(queues);
+            worker.setOrderedPriorityQueues(queues);
         }
     }
 

--- a/src/main/java/net/greghaines/jesque/worker/WorkerPoolImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerPoolImpl.java
@@ -25,10 +25,7 @@ import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.Callable;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -350,6 +347,11 @@ public class WorkerPoolImpl implements Worker {
         } else {
             this.queueNames.addAll(queues);
         }
+    }
+
+    @Override
+    public void setOrderedPriorityQueues(List<String> queues) {
+        throw new UnsupportedOperationException("Not implemented, yet");
     }
 
     /**

--- a/src/main/resources/workerScripts/fromMultiplePriorityQueues.lua
+++ b/src/main/resources/workerScripts/fromMultiplePriorityQueues.lua
@@ -1,0 +1,34 @@
+--
+-- User: Ofir Naor
+-- Date: 3/27/16
+-- Time: 2:47 PM
+--
+local queues = KEYS[1]
+--local debug = {'Hooray!', "'"..queues.."'"}
+
+local QUEUE_NAME_CAPTURING_REGEX = '([^,]+)'
+local OPTIONAL_COMMA_SEPARATOR = ',?'
+local OPTIONAL_SPACE_SEPARATOR = '%s*'
+local NEXT_QUEUE_REGEX = QUEUE_NAME_CAPTURING_REGEX .. OPTIONAL_COMMA_SEPARATOR .. OPTIONAL_SPACE_SEPARATOR
+
+for q in queues.gmatch(queues, NEXT_QUEUE_REGEX) do
+    local firstMsg = redis.call('ZRANGE', q, '0', '0')
+--    table.insert(debug, "q: " .. q)
+    if firstMsg ~= nil then
+--        table.insert(debug, 'result:')
+--        table.insert(debug, firstMsg)
+--        table.insert(debug, 'removed:')
+        local payload = firstMsg[1]
+        if payload ~= nil then
+            local removedItems = redis.call('ZREM', q, payload)
+--            table.insert(debug, payload)
+--            table.insert(debug, "num of removed items:")
+--            table.insert(debug, type(payload))
+            return payload
+--            return debug
+        end
+    end
+end
+--return debug
+--return "NOT_FOUND"
+return nil

--- a/src/main/resources/workerScripts/fromMultiplePriorityQueues.lua
+++ b/src/main/resources/workerScripts/fromMultiplePriorityQueues.lua
@@ -1,4 +1,4 @@
---
+-- new
 -- User: Ofir Naor
 -- Date: 3/27/16
 -- Time: 2:47 PM
@@ -12,23 +12,23 @@ local OPTIONAL_SPACE_SEPARATOR = '%s*'
 local NEXT_QUEUE_REGEX = QUEUE_NAME_CAPTURING_REGEX .. OPTIONAL_COMMA_SEPARATOR .. OPTIONAL_SPACE_SEPARATOR
 
 for q in queues.gmatch(queues, NEXT_QUEUE_REGEX) do
-    local firstMsg = redis.call('ZRANGE', q, '0', '0')
---    table.insert(debug, "q: " .. q)
-    if firstMsg ~= nil then
---        table.insert(debug, 'result:')
---        table.insert(debug, firstMsg)
---        table.insert(debug, 'removed:')
-        local payload = firstMsg[1]
-        if payload ~= nil then
-            local removedItems = redis.call('ZREM', q, payload)
---            table.insert(debug, payload)
---            table.insert(debug, "num of removed items:")
---            table.insert(debug, type(payload))
-            return payload
---            return debug
+    local queueName = 'resque:queue:' .. q
+    local status, queueType = next(redis.call('TYPE', queueName))
+    local payload
+    if queueType == 'zset' then
+        local firstMsg = redis.call('ZRANGE', queueName, '0', '0')
+        if firstMsg ~= nil then
+            payload = firstMsg[1]
+            if payload ~= nil then
+                local removedItems = redis.call('ZREM', queueName, payload)
+            end
         end
+    elseif queueType == 'list' then
+        payload = redis.call('LPOP', queueName)
+    end
+
+    if payload ~= nil then
+        return payload
     end
 end
---return debug
---return "NOT_FOUND"
 return nil

--- a/src/test/java/net/greghaines/jesque/worker/TestWorkerImpl.java
+++ b/src/test/java/net/greghaines/jesque/worker/TestWorkerImpl.java
@@ -1,5 +1,12 @@
 package net.greghaines.jesque.worker;
 
+import static net.greghaines.jesque.utils.JesqueUtils.entry;
+import static net.greghaines.jesque.utils.JesqueUtils.map;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
 import net.greghaines.jesque.Config;
 import net.greghaines.jesque.ConfigBuilder;
 import net.greghaines.jesque.TestAction;
@@ -10,13 +17,6 @@ import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Assert;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-
-import static net.greghaines.jesque.utils.JesqueUtils.entry;
-import static net.greghaines.jesque.utils.JesqueUtils.map;
 
 public class TestWorkerImpl {
     

--- a/src/test/java/net/greghaines/jesque/worker/TestWorkerPool.java
+++ b/src/test/java/net/greghaines/jesque/worker/TestWorkerPool.java
@@ -1,13 +1,5 @@
 package net.greghaines.jesque.worker;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
-
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
@@ -16,6 +8,15 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
 
 public class TestWorkerPool {
 
@@ -214,14 +215,27 @@ public class TestWorkerPool {
     
     @Test
     public void testSetQueues() {
-        final Collection<String> queues = Arrays.asList("queue1", "queue2");
+        final List<String> queues = Arrays.asList("queue1", "queue2");
         this.mockCtx.checking(new Expectations(){{
             oneOf(workers.get(0)).setQueues(queues);
             oneOf(workers.get(1)).setQueues(queues);
         }});
         this.pool.setQueues(queues);
     }
-    
+
+    @Test
+    public void testSetCollectionQueues() {
+        final Collection<String> queues = new HashSet<>();
+        queues.add("queue1");
+        queues.add("queue2");
+        final List<String> queuesAsList = Arrays.asList("queue1", "queue2");
+        this.mockCtx.checking(new Expectations(){{
+            oneOf(workers.get(0)).setQueues(queuesAsList);
+            oneOf(workers.get(1)).setQueues(queuesAsList);
+        }});
+        this.pool.setQueues(queues);
+    }
+
     @Test
     public void testGetJobFactory() {
         final Map<String, Class<?>> jobTypes = new LinkedHashMap<String, Class<?>>();

--- a/src/test/java/net/greghaines/jesque/worker/TestWorkerPool.java
+++ b/src/test/java/net/greghaines/jesque/worker/TestWorkerPool.java
@@ -214,24 +214,24 @@ public class TestWorkerPool {
     }
     
     @Test
-    public void testSetQueues() {
+    public void testSetQueuesList() {
         final List<String> queues = Arrays.asList("queue1", "queue2");
         this.mockCtx.checking(new Expectations(){{
-            oneOf(workers.get(0)).setQueues(queues);
-            oneOf(workers.get(1)).setQueues(queues);
+            oneOf(workers.get(0)).setOrderedPriorityQueues(queues);
+            oneOf(workers.get(1)).setOrderedPriorityQueues(queues);
         }});
-        this.pool.setQueues(queues);
+        this.pool.setOrderedPriorityQueues(queues);
     }
 
     @Test
-    public void testSetCollectionQueues() {
+    public void testSetQueuesCollection() {
         final Collection<String> queues = new HashSet<>();
         queues.add("queue1");
         queues.add("queue2");
         final List<String> queuesAsList = Arrays.asList("queue1", "queue2");
         this.mockCtx.checking(new Expectations(){{
-            oneOf(workers.get(0)).setQueues(queuesAsList);
-            oneOf(workers.get(1)).setQueues(queuesAsList);
+            oneOf(workers.get(0)).setOrderedPriorityQueues(queuesAsList);
+            oneOf(workers.get(1)).setOrderedPriorityQueues(queuesAsList);
         }});
         this.pool.setQueues(queues);
     }

--- a/src/test/java/net/greghaines/jesque/worker/TestWorkerPool.java
+++ b/src/test/java/net/greghaines/jesque/worker/TestWorkerPool.java
@@ -1,14 +1,5 @@
 package net.greghaines.jesque.worker;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JUnit4Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -17,6 +8,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 public class TestWorkerPool {
 


### PR DESCRIPTION
This PR adds ability to provide a list of queues 
`[first_priority, second_priority, third_priority, ...]`
 and receive the first message available.

This is done via a single _Redis_ command that iterates **_server-side**_ on the provided list of queues.

Suggestions how to improve this PR are welcome :tada:  
