### PR TITLE
Add possibility to just abort a job

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/DontPerformException.java
+++ b/src/main/java/net/greghaines/jesque/worker/DontPerformException.java
@@ -3,7 +3,8 @@ package net.greghaines.jesque.worker;
 /**
  * Force the execution of a job to be silently skipped.
  *
- * This exception may be thrown by {@link WorkerListener}s when handling the event {@link WorkerEvent#JOB_PROCESS}.
+ * This exception may be thrown by {@link WorkerListener}s when handling
+ * {@link WorkerEvent#JOB_PROCESS} or {@link WorkerEvent#JOB_EXECUTE}.
  */
 public class DontPerformException extends RuntimeException {
     /**

--- a/src/main/java/net/greghaines/jesque/worker/DontPerformException.java
+++ b/src/main/java/net/greghaines/jesque/worker/DontPerformException.java
@@ -1,0 +1,24 @@
+package net.greghaines.jesque.worker;
+
+/**
+ * Force the execution of a job to be silently skipped.
+ *
+ * This exception may be thrown by {@link WorkerListener}s when handling the event {@link WorkerEvent#JOB_PROCESS}.
+ */
+public class DontPerformException extends RuntimeException {
+    /**
+     * Default constructor.
+     */
+    public DontPerformException() {
+        super();
+    }
+
+    /**
+     * Constructor with message.
+     *
+     * @param message Message
+     */
+    public DontPerformException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -530,7 +530,7 @@ public class WorkerImpl implements Worker {
             final Object result = execute(job, curQueue, instance);
             success(job, instance, result, curQueue);
         } catch (DontPerformException e) {
-            // Just abort the job. Job is not considered a failure or a success.
+            // Just abort the job. Job is not considered a failure nor a success.
         } catch (Throwable thrwbl) {
             failure(thrwbl, job, curQueue);
         } finally {

--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -529,6 +529,8 @@ public class WorkerImpl implements Worker {
             final Object instance = this.jobFactory.materializeJob(job);
             final Object result = execute(job, curQueue, instance);
             success(job, instance, result, curQueue);
+        } catch (DontPerformException e) {
+            // Just abort the job. Job is not considered a failure or a success.
         } catch (Throwable thrwbl) {
             failure(thrwbl, job, curQueue);
         } finally {

--- a/src/main/java/net/greghaines/jesque/worker/WorkerListenerDelegate.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerListenerDelegate.java
@@ -135,8 +135,11 @@ public class WorkerListenerDelegate implements WorkerEventEmitter {
                 if (listener != null) {
                     try {
                         listener.onEvent(event, worker, queue, job, runner, result, t);
+                    } catch (DontPerformException e) {
+                        // Immediately abort execution of job.
+                        throw e;
                     } catch (Exception e) {
-                        log.error("Failure executing listener " + listener + " for event " + event 
+                        log.error("Failure executing listener " + listener + " for event " + event
                                 + " from queue " + queue + " on worker " + worker, e);
                     }
                 }

--- a/src/test/java/net/greghaines/jesque/DontPerformWorkerListener.java
+++ b/src/test/java/net/greghaines/jesque/DontPerformWorkerListener.java
@@ -1,0 +1,18 @@
+package net.greghaines.jesque;
+
+import net.greghaines.jesque.worker.DontPerformException;
+import net.greghaines.jesque.worker.Worker;
+import net.greghaines.jesque.worker.WorkerEvent;
+import net.greghaines.jesque.worker.WorkerListener;
+
+/**
+ * {@link WorkerListener} that throws a {@link DontPerformException} on {@link WorkerEvent#JOB_PROCESS}.
+ */
+public class DontPerformWorkerListener implements WorkerListener {
+    @Override
+    public void onEvent(WorkerEvent event, Worker worker, String queue, Job job, Object runner, Object result, Throwable t) {
+        if (WorkerEvent.JOB_PROCESS.equals(event)) {
+            throw new DontPerformException("test");
+        }
+    }
+}

--- a/src/test/java/net/greghaines/jesque/DontPerformWorkerListener.java
+++ b/src/test/java/net/greghaines/jesque/DontPerformWorkerListener.java
@@ -6,13 +6,27 @@ import net.greghaines.jesque.worker.WorkerEvent;
 import net.greghaines.jesque.worker.WorkerListener;
 
 /**
- * {@link WorkerListener} that throws a {@link DontPerformException} on {@link WorkerEvent#JOB_PROCESS}.
+ * {@link WorkerListener} that throws a {@link DontPerformException} on a given event.
  */
 public class DontPerformWorkerListener implements WorkerListener {
+    /**
+     * Event to answer with a {@link DontPerformException}.
+     */
+    private final WorkerEvent event;
+
+    /**
+     * Constructor.
+     *
+     * @param event Event to answer with a {@link DontPerformException}.
+     */
+    public DontPerformWorkerListener(WorkerEvent event) {
+        this.event = event;
+    }
+
     @Override
     public void onEvent(WorkerEvent event, Worker worker, String queue, Job job, Object runner, Object result, Throwable t) {
-        if (WorkerEvent.JOB_PROCESS.equals(event)) {
-            throw new DontPerformException("test");
+        if (event.equals(this.event)) {
+            throw new DontPerformException(event.name());
         }
     }
 }

--- a/src/test/java/net/greghaines/jesque/DurabilityTest.java
+++ b/src/test/java/net/greghaines/jesque/DurabilityTest.java
@@ -3,19 +3,18 @@ package net.greghaines.jesque;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.greghaines.jesque.json.ObjectMapperFactory;
 import net.greghaines.jesque.utils.JesqueUtils;
-import net.greghaines.jesque.utils.ResqueConstants;
 import net.greghaines.jesque.worker.MapBasedJobFactory;
 import net.greghaines.jesque.worker.Worker;
 import net.greghaines.jesque.worker.WorkerImpl;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
 import java.util.Arrays;
 
-import static net.greghaines.jesque.utils.ResqueConstants.QUEUE;
-import static net.greghaines.jesque.utils.ResqueConstants.QUEUES;
+import static net.greghaines.jesque.utils.ResqueConstants.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Test job durability:
@@ -38,6 +37,35 @@ public class DurabilityTest {
     }
 
     @Test
+    public void testDontPerform() throws Exception {
+        final String queue = "foo";
+        TestUtils.enqueueJobs(queue, Arrays.asList(new Job("SleepAction", 1L)), config);
+
+        final Worker worker = new WorkerImpl(config, Arrays.asList(queue),
+                new MapBasedJobFactory(JesqueUtils.map(JesqueUtils.entry("SleepAction", SleepAction.class))));
+        worker.getWorkerEventEmitter().addListener(new DontPerformWorkerListener());
+        final Thread workerThread = new Thread(worker);
+        workerThread.start();
+
+        Thread.sleep(1000);
+
+        final Jedis jedis = TestUtils.createJedis(config);
+        assertEquals("The job is not in flight anymore",
+                0, (long) jedis.llen(inFlightKey(worker, queue)));
+        assertNull("The job did not succeed", jedis.get(statKey(PROCESSED)));
+        assertNull("Job did not fail", jedis.get(statKey(FAILED)));
+        assertEquals("The job should have been removed from the queue",
+                0, (long) jedis.llen(queueKey(queue)));
+
+        worker.end(false);
+    }
+
+    private static String statKey(String key) {
+        return JesqueUtils.createKey(config.getNamespace(), STAT, key);
+    }
+
+
+    @Test
     public void testNotInterrupted() throws InterruptedException, JsonProcessingException {
         final String queue = "foo";
         TestUtils.enqueueJobs(queue, Arrays.asList(sleepJob), config);
@@ -50,18 +78,18 @@ public class DurabilityTest {
         Thread.sleep(1000);
 
         final Jedis jedis = TestUtils.createJedis(config);
-        Assert.assertEquals("In-flight list should have length one when running the job",
-                jedis.llen(inFlightKey(worker, queue)), (Long)1L);
-        Assert.assertEquals("Object on the in-flight list should be the first job",
-                ObjectMapperFactory.get().writeValueAsString(sleepJob), 
+        assertEquals("In-flight list should have length one when running the job",
+                1, (long) jedis.llen(inFlightKey(worker, queue)));
+        assertEquals("Object on the in-flight list should be the first job",
+                ObjectMapperFactory.get().writeValueAsString(sleepJob),
                 jedis.lindex(inFlightKey(worker, queue), 0));
 
         TestUtils.stopWorker(worker, workerThread, false);
 
-        Assert.assertTrue("The job should not be requeued after succesful processing",
-                jedis.llen(JesqueUtils.createKey(config.getNamespace(), QUEUE, queue)) == 0L);
-        Assert.assertEquals("In-flight list should be empty when finishing a job", 
-                jedis.llen(inFlightKey(worker, queue)), (Long)0L);
+        assertEquals("The job should not be requeued after successful processing",
+                0, (long) jedis.llen(queueKey(queue)));
+        assertEquals("In-flight list should be empty when finishing a job",
+                0, (long) jedis.llen(inFlightKey(worker, queue)));
     }
 
     @Test
@@ -77,10 +105,12 @@ public class DurabilityTest {
         TestUtils.stopWorker(worker, workerThread, true);
 
         final Jedis jedis = TestUtils.createJedis(config);
-        Assert.assertTrue("Job should be requeued", jedis.llen(JesqueUtils.createKey(config.getNamespace(), QUEUE, queue)) == 1L);
-        Assert.assertEquals("Incorrect job was requeued", ObjectMapperFactory.get().writeValueAsString(sleepJob),
-                jedis.lindex(JesqueUtils.createKey(config.getNamespace(), QUEUE, queue), 0));
-        Assert.assertTrue("In-flight list should be empty when finishing a job", jedis.llen(inFlightKey(worker, queue)) == 0L);
+        assertEquals("Job should be requeued",
+                1, (long) jedis.llen(queueKey(queue)));
+        assertEquals("Incorrect job was requeued", ObjectMapperFactory.get().writeValueAsString(sleepJob),
+                jedis.lindex(queueKey(queue), 0));
+        assertEquals("In-flight list should be empty when finishing a job",
+                0, (long) jedis.llen(inFlightKey(worker, queue)));
     }
 
     @Test
@@ -92,7 +122,7 @@ public class DurabilityTest {
         // Submit a job containing incorrect JSON.
         String incorrectJson = "{";
         jedis.sadd(JesqueUtils.createKey(config.getNamespace(), QUEUES), queue);
-        jedis.rpush(JesqueUtils.createKey(config.getNamespace(), QUEUE, queue), incorrectJson);
+        jedis.rpush(queueKey(queue), incorrectJson);
 
         final Worker worker = new WorkerImpl(config, Arrays.asList(queue),
                 new MapBasedJobFactory(JesqueUtils.map(JesqueUtils.entry("SleepAction", SleepAction.class))));
@@ -103,11 +133,15 @@ public class DurabilityTest {
 
         TestUtils.stopWorker(worker, workerThread, false);
 
-        Assert.assertEquals("In-flight list should have length zero if the worker failed during JSON deserialization",
-                jedis.llen(inFlightKey(worker, queue)), (Long) 0L);
+        assertEquals("In-flight list should have length zero if the worker failed during JSON deserialization",
+                0, (long) jedis.llen(inFlightKey(worker, queue)));
+    }
+
+    private static String queueKey(final String queue) {
+        return JesqueUtils.createKey(config.getNamespace(), QUEUE, queue);
     }
 
     private static String inFlightKey(final Worker worker, final String queue) {
-        return JesqueUtils.createKey(config.getNamespace(), ResqueConstants.INFLIGHT, worker.getName(), queue);
+        return JesqueUtils.createKey(config.getNamespace(), INFLIGHT, worker.getName(), queue);
     }
 }


### PR DESCRIPTION
This is considered to be the equivalent to Resque::Job::DontPerform. 

DontPerformException may be thrown by a WorkerListener on JOB_PROCESS to silently skip the job to be executed. The job won't be counted as "processed" nor "failed". The WorkerListener may re-enqueue the job after a delay, if required.