### PR TITLE
when redis has no password,

### DIFF
--- a/src/main/java/net/greghaines/jesque/client/ClientImpl.java
+++ b/src/main/java/net/greghaines/jesque/client/ClientImpl.java
@@ -176,7 +176,7 @@ public class ClientImpl extends AbstractClient {
     }
 
     private void authenticateAndSelectDB() {
-        if (this.config.getPassword() != null) {
+        if (this.config.getPassword() != null && !"".equals(this.config.getPassword())) {
             this.jedis.auth(this.config.getPassword());
         }
         this.jedis.select(this.config.getDatabase());

--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -553,7 +553,7 @@ public class WorkerImpl implements Worker {
     }
 
     private void authenticateAndSelectDB() {
-        if (this.config.getPassword() != null) {
+        if (this.config.getPassword() != null && !"".equals(this.config.getPassword())) {
             this.jedis.auth(this.config.getPassword());
         }
         this.jedis.select(this.config.getDatabase());


### PR DESCRIPTION
fix the ClientImpl and WorkerImpl about the auth code

when I config the net.greghaines.jesque.Config in spring config file. and My redis server has no password.
It will throw a error.Because the password is not null but it's a empty string.

`<bean id="jesqueConfig" class="net.greghaines.jesque.Config">
		    <constructor-arg value="172.16.0.173" />
		    <constructor-arg value="6379" />
		    <constructor-arg value="2000" />
		    <constructor-arg value="" />
		    <constructor-arg value="psq-resque" />
		    <constructor-arg value="1" />
		</bean>`
so do the worker