### PR TITLE
allow to set a max number of failed items to keep via FailQueueStrategy

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/DefaultFailQueueStrategy.java
+++ b/src/main/java/net/greghaines/jesque/worker/DefaultFailQueueStrategy.java
@@ -21,7 +21,8 @@ import net.greghaines.jesque.Job;
 import net.greghaines.jesque.utils.JesqueUtils;
 
 /**
- * DefaultFailQueueStrategy puts all jobs in the standard Redis failure queue.
+ * DefaultFailQueueStrategy puts all jobs in the standard Redis failure queue
+ * and imposes no limits on the max number of failed items to keep.
  */
 public class DefaultFailQueueStrategy implements FailQueueStrategy {
 
@@ -41,5 +42,13 @@ public class DefaultFailQueueStrategy implements FailQueueStrategy {
     @Override
     public String getFailQueueKey(final Throwable thrwbl, final Job job, final String curQueue) {
         return JesqueUtils.createKey(this.namespace, FAILED);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getFailQueueMaxItems(String curQueue) {
+        return 0;
     }
 }

--- a/src/main/java/net/greghaines/jesque/worker/FailQueueStrategy.java
+++ b/src/main/java/net/greghaines/jesque/worker/FailQueueStrategy.java
@@ -32,4 +32,12 @@ public interface FailQueueStrategy {
      * @return the key of the failure queue to put the job into or null
      */
     String getFailQueueKey(Throwable thrwbl, Job job, String curQueue);
+
+    /**
+     * Determine the max number of items to keep in the failure queue.
+     * Returning a value <1 means that there is no limit.
+     * @param curQueue the queue the Job came from
+     * @return the max number of items to keep for the failure queue
+     */
+    int getFailQueueMaxItems(String curQueue);
 }


### PR DESCRIPTION
By default there is no upper limit for the amount of items to keep in a failed queue.
If there are many failing jobs with huge stacktraces, the redis instance may go OOM.

We're currently doing this in our own `execute` implementation, would be nice to have this upstream so others could use this as well.