### PR TITLE
Add sleep before worker.end(true) in main thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ final Worker worker = new WorkerImpl(config,
 final Thread workerThread = new Thread(worker);
 workerThread.start();
 
+Thread.sleep(100);
 worker.end(true);
 try { workerThread.join(); } catch (Exception e){ e.printStackTrace(); }
 ```


### PR DESCRIPTION
Sometimes, there may be issue if worker.end(true) takes effect before workerThread.run(). Below exception is thrown:

Exception in thread "Thread-0" java.lang.IllegalStateException: This WorkerImpl is shutdown
	at net.greghaines.jesque.worker.WorkerImpl.run(WorkerImpl.java:258)
Disconnected from the target VM, address: '127.0.0.1:64449', transport: 'socket'
	at java.lang.Thread.run(Thread.java:745)