### PR TITLE
Upgrade to jackson 2.9.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 target/
 *.class
 stdout
+.idea/
+jesque.iml
+

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jedis.version>2.9.0</jedis.version>
-        <jackson.version>2.8.5</jackson.version>
+        <jackson.version>2.9.5</jackson.version>
         <slf4j.version>1.7.21</slf4j.version>
         <logback.version>1.1.7</logback.version>
         <junit.version>4.12</junit.version>

--- a/src/main/java/net/greghaines/jesque/json/ObjectMapperFactory.java
+++ b/src/main/java/net/greghaines/jesque/json/ObjectMapperFactory.java
@@ -15,12 +15,11 @@
  */
 package net.greghaines.jesque.json;
 
-import java.text.DateFormat;
-
-import net.greghaines.jesque.utils.CompositeDateFormat;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import net.greghaines.jesque.utils.CompositeDateFormat;
+
+import java.text.DateFormat;
 
 /**
  * A helper that creates a fully-configured singleton ObjectMapper.
@@ -34,8 +33,7 @@ public final class ObjectMapperFactory {
 	static {
 		mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 		final DateFormat jsonDateFormat = new CompositeDateFormat();
-		mapper.getDeserializationConfig().with(jsonDateFormat);
-		mapper.getSerializationConfig().with(jsonDateFormat);
+		mapper.setDateFormat(jsonDateFormat);
 	}
 	
 	/**

--- a/src/main/java/net/greghaines/jesque/utils/CompositeDateFormat.java
+++ b/src/main/java/net/greghaines/jesque/utils/CompositeDateFormat.java
@@ -17,11 +17,13 @@ package net.greghaines.jesque.utils;
 
 import java.io.Serializable;
 import java.text.DateFormat;
+import java.text.DecimalFormat;
 import java.text.FieldPosition;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
 
@@ -51,6 +53,12 @@ public class CompositeDateFormat extends DateFormat {
         new PatternDateFormatFactory(ResqueConstants.DATE_FORMAT_RUBY_V4),
         new PatternDateFormatFactory(ResqueConstants.DATE_FORMAT_PHP)
     );
+
+    public CompositeDateFormat() {
+        super();
+        setCalendar(new GregorianCalendar());
+        setNumberFormat(new DecimalFormat());
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
I think my pull request addresses this issue: https://github.com/gresrun/jesque/issues/137

I suspect the problem will become more common. DropWizard (our framework) upgraded to Jackson 2.9.x at version 1.2 and they are at 1.3.1 now. 

The upgrade broke how the date serializer worked. I verified that all unit tests pass. I also verified through my app that normal queuing, delayed queuing, and scheduled recurring queuing all work. Workers also pick up and process jobs as expected.

Thank you for putting this project out, it's very useful.