### PR TITLE
fix case where we missed pushing a JobFailure

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -691,6 +691,8 @@ public class WorkerImpl implements Worker {
                         tx.ltrim(failQueueKey, 1, -1);
                         tx.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
                         tx.exec();
+                    } else {
+                        this.jedis.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
                     }
                 } else {
                     this.jedis.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));

--- a/src/main/java/net/greghaines/jesque/worker/WorkerPoolImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerPoolImpl.java
@@ -750,6 +750,8 @@ public class WorkerPoolImpl implements Worker {
                                 tx.ltrim(failQueueKey, 1, -1);
                                 tx.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
                                 tx.exec();
+                            } else {
+                                jedis.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
                             }
                         } else {
                             jedis.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));


### PR DESCRIPTION
we missed pushing the JobFailure in the case when there is a fail queue item limit and the current number of failed items is 0

the fix is to call rpush in this case as well