### PR TITLE
add runAt property to job

### DIFF
--- a/src/main/java/net/greghaines/jesque/Job.java
+++ b/src/main/java/net/greghaines/jesque/Job.java
@@ -43,6 +43,7 @@ public class Job implements Serializable {
     private Object[] args;
     private Map<String,Object> vars;
     private Map<String,Object> unknownFields = new HashMap<String,Object>();
+    private Double runAt; // only set if this job belongs to a delayed queue
 
     /**
      * No-argument constructor.
@@ -192,6 +193,16 @@ public class Job implements Serializable {
     @SuppressWarnings("unchecked")
     public void setVars(final Map<String, ? extends Object> vars) {
         this.vars = (Map<String, Object>)vars;
+    }
+
+    @JsonIgnore
+    public Double getRunAt() {
+        return runAt;
+    }
+
+    @JsonIgnore
+    public void setRunAt(Double runAt) {
+        this.runAt = runAt;
     }
 
     /**


### PR DESCRIPTION
This patch adds a `runAt` property to the `Job` class. 
The property is set by `QueueInfoDAORedisImpl#getQueueInfo`, but only when the queue is a delayed one.
The property is exposed via `QueueInfo.getJobs()*.runAt`.