### PR TITLE
add pending property to QueueInfo

### DIFF
--- a/src/main/java/net/greghaines/jesque/meta/QueueInfo.java
+++ b/src/main/java/net/greghaines/jesque/meta/QueueInfo.java
@@ -34,6 +34,7 @@ public class QueueInfo implements Comparable<QueueInfo>, Serializable {
     private Long size;
     private List<Job> jobs;
     private Boolean delayed;
+    private Long pending; // only set if this queue is delayed
 
     /**
      * @return the name of the queue
@@ -92,6 +93,20 @@ public class QueueInfo implements Comparable<QueueInfo>, Serializable {
     }
 
     /**
+     * @return the number of pending jobs in the queue
+     */
+    public Long getPending() {
+        return this.pending;
+    }
+
+    /**
+     * @param pending the number of pending jobs in the queue
+     */
+    public void setPending(final Long pending) {
+        this.pending = pending;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -110,6 +125,7 @@ public class QueueInfo implements Comparable<QueueInfo>, Serializable {
         result = prime * result + ((this.name == null) ? 0 : this.name.hashCode());
         result = prime * result + ((this.size == null) ? 0 : this.size.hashCode());
         result = prime * result + ((this.delayed == null) ? 0 : this.delayed.hashCode());
+        result = prime * result + ((this.pending == null) ? 0 : this.pending.hashCode());
         return result;
     }
 
@@ -126,7 +142,8 @@ public class QueueInfo implements Comparable<QueueInfo>, Serializable {
             equal = (JesqueUtils.nullSafeEquals(this.jobs, other.jobs)
                     && JesqueUtils.nullSafeEquals(this.name, other.name)
                     && JesqueUtils.nullSafeEquals(this.size, other.size)
-                    && JesqueUtils.nullSafeEquals(this.delayed, other.delayed));
+                    && JesqueUtils.nullSafeEquals(this.delayed, other.delayed)
+                    && JesqueUtils.nullSafeEquals(this.pending, other.pending));
         }
         return equal;
     }

--- a/src/main/java/net/greghaines/jesque/meta/dao/impl/QueueInfoDAORedisImpl.java
+++ b/src/main/java/net/greghaines/jesque/meta/dao/impl/QueueInfoDAORedisImpl.java
@@ -139,6 +139,9 @@ public class QueueInfoDAORedisImpl implements QueueInfoDAO {
                     queueInfo.setName(queueName);
                     queueInfo.setSize(size(jedis, queueName));
                     queueInfo.setDelayed(delayed(jedis, queueName));
+                    if (queueInfo.isDelayed()) {
+                        queueInfo.setPending(pending(jedis, queueName));
+                    }
                     queueInfos.add(queueInfo);
                 }
                 Collections.sort(queueInfos);
@@ -162,6 +165,9 @@ public class QueueInfoDAORedisImpl implements QueueInfoDAO {
                 queueInfo.setName(name);
                 queueInfo.setSize(size(jedis, name));
                 queueInfo.setDelayed(delayed(jedis, name));
+                if (queueInfo.isDelayed()) {
+                    queueInfo.setPending(pending(jedis, name));
+                }
                 final List<Job> jobs = getJobs(jedis, name, jobOffset, jobCount);
                 queueInfo.setJobs(jobs);
                 return queueInfo;
@@ -219,6 +225,11 @@ public class QueueInfoDAORedisImpl implements QueueInfoDAO {
             size = jedis.llen(key);
         }
         return size;
+    }
+
+    private long pending(final Jedis jedis, final String queueName) {
+        final String key = key(QUEUE, queueName);
+        return jedis.zcount(key, 0, System.currentTimeMillis());
     }
 
     /**

--- a/src/test/java/net/greghaines/jesque/meta/dao/impl/TestQueueInfoDAORedisImpl.java
+++ b/src/test/java/net/greghaines/jesque/meta/dao/impl/TestQueueInfoDAORedisImpl.java
@@ -168,6 +168,7 @@ public class TestQueueInfoDAORedisImpl {
                 exactly(2).of(jedis).type(queueKey); will(returnValue(e.getValue()));
                 if (KeyType.ZSET.toString().equals(e.getValue())) {
                     oneOf(jedis).zcard(queueKey); will(returnValue(queueCountMap.get(e.getKey())));
+                    oneOf(jedis).zcount(with(equal(queueKey)), with(equal(0.0)), with(any(Double.class))); will(returnValue(1L));
                 } else {
                     oneOf(jedis).llen(queueKey); will(returnValue(queueCountMap.get(e.getKey())));
                 }
@@ -223,6 +224,7 @@ public class TestQueueInfoDAORedisImpl {
             oneOf(pool).getResource(); will(returnValue(jedis));
             exactly(3).of(jedis).type(queueKey); will(returnValue(KeyType.ZSET.toString()));
             oneOf(jedis).zcard(queueKey); will(returnValue(size));
+            oneOf(jedis).zcount(with(equal(queueKey)), with(equal(0.0)), with(any(Double.class))); will(returnValue(jobCount));
             oneOf(jedis).zrangeWithScores(queueKey, jobOffset, jobOffset + jobCount - 1); will(returnValue(payloads));
             oneOf(jedis).close();
         }});


### PR DESCRIPTION
For delayed queues, the size property may be misleading,
as it shows all jobs that are enqueued in that queue.

This patch adds a `pending` property to the QueueInfo class
which shows the number of jobs in a delayed queue that are
eligible for execution by a worker.