### PR TITLE
Add functionality to enqueue jobs in batches

### DIFF
--- a/src/main/java/net/greghaines/jesque/client/AbstractClient.java
+++ b/src/main/java/net/greghaines/jesque/client/AbstractClient.java
@@ -90,17 +90,9 @@ public abstract class AbstractClient implements Client {
      */
     @Override
     public void enqueue(final String queue, final List<Job> jobs) {
-        if (queue == null || "".equals(queue)) {
-            throw new IllegalArgumentException("queue must not be null or empty: " + queue);
-        }
-
+        validateQueue(queue);
         for(Job job: jobs) {
-            if (job == null) {
-                throw new IllegalArgumentException("job must not be null");
-            }
-            if (!job.isValid()) {
-                throw new IllegalStateException("job is not valid: " + job);
-            }
+            validateJob(job);
         }
 
         try {
@@ -456,9 +448,17 @@ public abstract class AbstractClient implements Client {
     }
 
     private static void validateArguments(final String queue, final Job job) {
+        validateQueue(queue);
+        validateJob(job);
+    }
+
+    private static void validateQueue(String queue) {
         if (queue == null || "".equals(queue)) {
             throw new IllegalArgumentException("queue must not be null or empty: " + queue);
         }
+    }
+
+    private static void validateJob(Job job) {
         if (job == null) {
             throw new IllegalArgumentException("job must not be null");
         }

--- a/src/main/java/net/greghaines/jesque/client/Client.java
+++ b/src/main/java/net/greghaines/jesque/client/Client.java
@@ -17,6 +17,8 @@ package net.greghaines.jesque.client;
 
 import net.greghaines.jesque.Job;
 
+import java.util.List;
+
 /**
  * A Client allows Jobs to be enqueued for execution by Workers.
  * 
@@ -36,6 +38,18 @@ public interface Client {
      *             if the queue is null or empty or if the job is null
      */
     void enqueue(String queue, Job job);
+
+    /**
+     * Queues a list of jobs in a given queue to be run.
+     *
+     * @param queue
+     *            the queue to add the Job to
+     * @param jobs
+     *            the list of jobs to be enqueued
+     * @throws IllegalArgumentException
+     *             if the queue is null or empty or if the list of job is null
+     */
+    void enqueue(String queue, List<Job> jobs);
 
     /**
      * Queues a job with high priority in a given queue to be run.

--- a/src/main/java/net/greghaines/jesque/client/ClientImpl.java
+++ b/src/main/java/net/greghaines/jesque/client/ClientImpl.java
@@ -15,6 +15,7 @@
  */
 package net.greghaines.jesque.client;
 
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -107,6 +108,12 @@ public class ClientImpl extends AbstractClient {
     protected void doEnqueue(final String queue, final String jobJson) {
         ensureJedisConnection();
         doEnqueue(this.jedis, getNamespace(), queue, jobJson);
+    }
+
+    @Override
+    protected void doEnqueue(String queue, List<String> jobJsons) {
+        ensureJedisConnection();
+        doEnqueue(this.jedis, getNamespace(), queue, jobJsons);
     }
 
     /**

--- a/src/main/java/net/greghaines/jesque/client/ClientPoolImpl.java
+++ b/src/main/java/net/greghaines/jesque/client/ClientPoolImpl.java
@@ -21,6 +21,8 @@ import net.greghaines.jesque.utils.PoolUtils.PoolWork;
 import redis.clients.jedis.Jedis;
 import redis.clients.util.Pool;
 
+import java.util.List;
+
 /**
  * A Client implementation that gets its connection to Redis from a connection
  * pool.
@@ -60,6 +62,20 @@ public class ClientPoolImpl extends AbstractClient {
             @Override
             public Void doWork(final Jedis jedis) {
                 doEnqueue(jedis, getNamespace(), queue, jobJson);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    protected void doEnqueue(final String queue, final List<String> jobJsons) throws Exception {
+        PoolUtils.doWorkInPool(this.jedisPool, new PoolWork<Jedis, Void>() {
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public Void doWork(final Jedis jedis) {
+                doEnqueue(jedis, getNamespace(), queue, jobJsons);
                 return null;
             }
         });

--- a/src/test/java/net/greghaines/jesque/ClientBeforeWorkerTest.java
+++ b/src/test/java/net/greghaines/jesque/ClientBeforeWorkerTest.java
@@ -55,7 +55,7 @@ public class ClientBeforeWorkerTest {
     public void issue18() throws Exception {
         // Enqueue the job before worker is created and started
         final Job job = new Job("TestAction", new Object[] { 1, 2.3, true, "test", Arrays.asList("inner", 4.5) });
-        TestUtils.enqueueJobs(testQueue, Arrays.asList(job), config);
+        TestUtils.enqueueJob(testQueue, job, config);
         Jedis jedis = createJedis(config);
         try { // Assert that we enqueued the job
             Assert.assertEquals(Long.valueOf(1), jedis.llen(createKey(config.getNamespace(), QUEUE, testQueue)));

--- a/src/test/java/net/greghaines/jesque/DurabilityTest.java
+++ b/src/test/java/net/greghaines/jesque/DurabilityTest.java
@@ -42,7 +42,7 @@ public class DurabilityTest {
     @Test
     public void testNotInterrupted() throws InterruptedException, JsonProcessingException {
         final String queue = "foo";
-        TestUtils.enqueueJobs(queue, Arrays.asList(sleepJob), config);
+        TestUtils.enqueueJob(queue, sleepJob, config);
 
         final Worker worker = new WorkerImpl(config, Arrays.asList(queue),
                 new MapBasedJobFactory(JesqueUtils.map(JesqueUtils.entry("SleepAction", SleepAction.class))));
@@ -69,7 +69,7 @@ public class DurabilityTest {
     @Test
     public void testInterruptedNoExceptionJobSucceeds() {
         final String queue = "bar";
-        TestUtils.enqueueJobs(queue, Arrays.asList(sleepJob), config);
+        TestUtils.enqueueJob(queue, sleepJob, config);
 
         final Worker worker = new WorkerImpl(config, Arrays.asList(queue),
                 new MapBasedJobFactory(JesqueUtils.map(JesqueUtils.entry("SleepAction", SleepAction.class))));
@@ -86,7 +86,7 @@ public class DurabilityTest {
     @Test
     public void testInterrupted() throws JsonProcessingException {
         final String queue = "bar";
-        TestUtils.enqueueJobs(queue, Arrays.asList(sleepWithExceptionJob), config);
+        TestUtils.enqueueJob(queue, sleepWithExceptionJob, config);
 
         final Worker worker = new WorkerImpl(config, Arrays.asList(queue),
                 new MapBasedJobFactory(JesqueUtils.map(JesqueUtils.entry("SleepWithExceptionAction", SleepWithExceptionAction.class))));

--- a/src/test/java/net/greghaines/jesque/InfiniteTest.java
+++ b/src/test/java/net/greghaines/jesque/InfiniteTest.java
@@ -48,7 +48,7 @@ public class InfiniteTest {
         final Thread workerThread = new Thread(worker);
         workerThread.start();
 
-        TestUtils.enqueueJobs("inf", Arrays.asList(new Job("InfiniteAction")), config);
+        TestUtils.enqueueJob("inf", new Job("InfiniteAction"), config);
         final Worker worker2 = new WorkerImpl(config, Arrays.asList("inf"), 
                 new MapBasedJobFactory(map(entry("InfiniteAction", InfiniteAction.class))));
         final Thread workerThread2 = new Thread(worker2);

--- a/src/test/java/net/greghaines/jesque/Issue46.java
+++ b/src/test/java/net/greghaines/jesque/Issue46.java
@@ -51,7 +51,7 @@ public class Issue46 {
         final Thread workerThread = new Thread(worker);
         workerThread.start();
         try {
-            TestUtils.enqueueJobs(TEST_QUEUE, Arrays.asList(job), CONFIG);
+            TestUtils.enqueueJob(TEST_QUEUE, job, CONFIG);
         } finally {
             TestUtils.stopWorker(worker, workerThread);
         }

--- a/src/test/java/net/greghaines/jesque/LongRunningTest.java
+++ b/src/test/java/net/greghaines/jesque/LongRunningTest.java
@@ -49,7 +49,7 @@ public class LongRunningTest {
     @Ignore
     public void issue28() throws InterruptedException {
         changeRedisTimeout(10);
-        TestUtils.enqueueJobs("longRunning", Arrays.asList(new Job("LongRunningAction", 20 * 1000L)), config);
+        TestUtils.enqueueJob("longRunning", new Job("LongRunningAction", 20 * 1000L), config);
         final Worker worker2 = new WorkerImpl(config, Arrays.asList("longRunning"), 
                 new MapBasedJobFactory(map(entry("LongRunningAction", LongRunningAction.class))));
         final AtomicBoolean successRef = new AtomicBoolean(false);

--- a/src/test/java/net/greghaines/jesque/TestUtils.java
+++ b/src/test/java/net/greghaines/jesque/TestUtils.java
@@ -72,12 +72,10 @@ public final class TestUtils {
         return jedis;
     }
 
-    public static void enqueueJobs(final String queue, final List<Job> jobs, final Config config) {
+    public static void enqueueJob(final String queue, final Job job, final Config config) {
         final Client client = new ClientImpl(config);
         try {
-            for (final Job job : jobs) {
-                client.enqueue(queue, job);
-            }
+            client.enqueue(queue, job);
         } finally {
             client.end();
         }

--- a/src/test/java/net/greghaines/jesque/TestUtils.java
+++ b/src/test/java/net/greghaines/jesque/TestUtils.java
@@ -83,6 +83,15 @@ public final class TestUtils {
         }
     }
 
+    public static void enqueueJobs(final String queue, final List<Job> jobs, final Config config) {
+        final Client client = new ClientImpl(config);
+        try {
+            client.enqueue(queue, jobs);
+        } finally {
+            client.end();
+        }
+    }
+
     public static void stopWorker(final JobExecutor worker, final Thread workerThread) {
         stopWorker(worker, workerThread, false);
     }


### PR DESCRIPTION
We are using Jesque to enqueue a lot (up to 100 000) of jobs at once. Doing it in a normal, sequential way is not performant enough - we observed an average enqueuing time of 1ms/job. This can be significantly improved by either using [pipelininig](https://redis.io/topics/pipelining) or [transactions](https://redis.io/topics/transactions) feature of Redis.
Since it is easier to implement the batching functionality using transactions, as there is no need to handle situations in which only a subset of jobs has been successfully scheduled, this is what this implementation is using.
Note: Transactions are handled by Redis v1.2 and higher. 
Testing it locally, it took 16s to enqueue 10k jobs one by one and 400ms in batching mode.

This implementation **does not** take care of splitting the batch into chunks of 10k, or less, queries (as advised in the document above). **This might potentially lead to increased memory use on Redis**.

closes #123