### PR TITLE
upgrade to jackson 2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jedis.version>2.9.0</jedis.version>
-        <jackson.version>2.9.6</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Hi,
This PR updates jackson to version 2.9.8, since 2.9.6 has known vulnerabilities.

Snyk: https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72449

CVEs: CVE-2018-14718, CVE-2018-14719, CVE-2018-14720, CVE-2018-14721, CVE-2018-14722, CVE-2018-14723
CWEs: [CWE-502](https://cwe.mitre.org/data/definitions/502.html)
