### PR TITLE
proper resizing of failed item queue

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerImpl.java
@@ -689,15 +689,10 @@ public class WorkerImpl implements Worker {
             if (failQueueKey != null) {
                 final int failQueueMaxItems = strategy.getFailQueueMaxItems(curQueue);
                 if (failQueueMaxItems > 0) {
-                    Long currentItems = this.jedis.llen(failQueueKey);
-                    if (currentItems >= failQueueMaxItems) {
-                        Transaction tx = this.jedis.multi();
-                        tx.ltrim(failQueueKey, 1, -1);
-                        tx.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
-                        tx.exec();
-                    } else {
-                        this.jedis.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
-                    }
+                    Transaction tx = this.jedis.multi();
+                    tx.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
+                    tx.ltrim(failQueueKey, -failQueueMaxItems, -1);
+                    tx.exec();
                 } else {
                     this.jedis.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
                 }

--- a/src/main/java/net/greghaines/jesque/worker/WorkerPoolImpl.java
+++ b/src/main/java/net/greghaines/jesque/worker/WorkerPoolImpl.java
@@ -755,15 +755,10 @@ public class WorkerPoolImpl implements Worker {
                     if (failQueueKey != null) {
                         final int failQueueMaxItems = strategy.getFailQueueMaxItems(curQueue);
                         if (failQueueMaxItems > 0) {
-                            Long currentItems = jedis.llen(failQueueKey);
-                            if (currentItems >= failQueueMaxItems) {
-                                Transaction tx = jedis.multi();
-                                tx.ltrim(failQueueKey, 1, -1);
-                                tx.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
-                                tx.exec();
-                            } else {
-                                jedis.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
-                            }
+                            Transaction tx = jedis.multi();
+                            tx.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
+                            tx.ltrim(failQueueKey, -failQueueMaxItems, -1);
+                            tx.exec();
                         } else {
                             jedis.rpush(failQueueKey, failMsg(thrwbl, curQueue, job));
                         }


### PR DESCRIPTION
the number of items to keep in the failed queue can not be downsized. the problem is that we always only remove max. 1 item with the `ltrim`. the fix is to trim the list to exactly the size we want.
we also don't need to check the size of the failed queue before trimming, as we can simply `ltrim` all the time now.