### PR TITLE
allow retrieval of failed job counter

### DIFF
--- a/src/main/java/net/greghaines/jesque/meta/dao/FailureDAO.java
+++ b/src/main/java/net/greghaines/jesque/meta/dao/FailureDAO.java
@@ -28,9 +28,14 @@ import net.greghaines.jesque.JobFailure;
 public interface FailureDAO {
     
     /**
-     * @return total number of failures
+     * @return total number of jobs that failed
      */
     long getCount();
+
+    /**
+     * @return number of jobs in the fail queue
+     */
+    long getFailQueueJobCount();
 
     /**
      * @param offset offset into the failures

--- a/src/main/java/net/greghaines/jesque/meta/dao/impl/FailureDAORedisImpl.java
+++ b/src/main/java/net/greghaines/jesque/meta/dao/impl/FailureDAORedisImpl.java
@@ -18,6 +18,7 @@ package net.greghaines.jesque.meta.dao.impl;
 import static net.greghaines.jesque.utils.ResqueConstants.FAILED;
 import static net.greghaines.jesque.utils.ResqueConstants.QUEUE;
 import static net.greghaines.jesque.utils.ResqueConstants.QUEUES;
+import static net.greghaines.jesque.utils.ResqueConstants.STAT;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -67,6 +68,23 @@ public class FailureDAORedisImpl implements FailureDAO {
      */
     @Override
     public long getCount() {
+        return PoolUtils.doWorkInPoolNicely(this.jedisPool, new PoolWork<Jedis, Long>() {
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public Long doWork(final Jedis jedis) throws Exception {
+                final String failedStr = jedis.get(key(STAT, FAILED));
+                return (failedStr == null) ? 0L : Long.parseLong(failedStr);
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getFailQueueJobCount() {
         return PoolUtils.doWorkInPoolNicely(this.jedisPool, new PoolWork<Jedis, Long>() {
             /**
              * {@inheritDoc}


### PR DESCRIPTION
the failure dao currently only provides a counter for the amount of jobs
in the failed queue. this patch adds the possibility to retrieve the value
of the global failed job counter which is at `resque:stat:failed`.