### PR TITLE
fix detection of redis loading the dataset

### DIFF
--- a/src/main/java/net/greghaines/jesque/worker/DefaultPoolExceptionHandler.java
+++ b/src/main/java/net/greghaines/jesque/worker/DefaultPoolExceptionHandler.java
@@ -35,7 +35,7 @@ public class DefaultPoolExceptionHandler implements ExceptionHandler {
 	public RecoveryStrategy onException(final JobExecutor jobExecutor, final Exception exception,
 	        final String curQueue) {
 		final boolean isLoadingDataset = exception instanceof JedisDataException
-				&& exception.getMessage().equals("LOADING Redis is loading the dataset in memory");
+				&& exception.getMessage().startsWith("LOADING Redis is loading the dataset in memory");
 
 		if (exception instanceof JedisConnectionException
 				|| exception instanceof JedisNoScriptException


### PR DESCRIPTION
we just discovered that the reconnect implemented in #149 does not work properly: the exception message has a [\r\n at the end](https://github.com/redis/redis/blob/unstable/src/server.c#L2240). so calling `equals` always returns false and hence the workers will terminate.
the fix is to call `startsWith` instead.